### PR TITLE
Fix last_error field in monitoring health status

### DIFF
--- a/monitoring.py
+++ b/monitoring.py
@@ -414,7 +414,7 @@ class CrawlerMonitor:
             'success_rate': success_rate,
             'avg_response_time': avg_response_time,
             'last_success': metrics.last_success,
-            'last_error': metrics.last_success,
+            'last_error': metrics.last_error,
             'circuit_open': metrics.circuit_open
         }
     


### PR DESCRIPTION
## Summary
- ensure `last_error` uses correct `metrics.last_error` value in `get_health_status`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840651816dc832fa41ffaa246c34910