### PR TITLE
Remove stray import comments

### DIFF
--- a/main_crawler.py
+++ b/main_crawler.py
@@ -10,11 +10,10 @@ from crawl4ai.extraction_strategy import LLMExtractionStrategy
 from hazm import Normalizer
 from persian_tools import digits
 import jdatetime
-# Add these imports at the top
 from monitoring import CrawlerMonitor, ErrorHandler
 from data_manager import FlightDataManager, DataManager
 from site_crawlers import FlytodayCrawler, AlibabaCrawler, SafarmarketCrawler
-from crawl4ai.cache_mode import CacheMode  # Missing import
+from crawl4ai.cache_mode import CacheMode
 from rate_limiter import RateLimiter
 from persian_text import PersianTextProcessor
 from config import config


### PR DESCRIPTION
## Summary
- remove leftover guidance comment about imports in `main_crawler.py`
- drop inline comment about a missing import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406517deb0832fb35610c80c1a9313