### PR TITLE
Add parse_time test

### DIFF
--- a/tests/test_persian_text_processor.py
+++ b/tests/test_persian_text_processor.py
@@ -25,3 +25,11 @@ def test_parse_persian_date():
     assert isinstance(result, datetime.datetime)
     assert result.date() == datetime.date(2023, 11, 6)
 
+
+def test_parse_time():
+    processor = PersianTextProcessor()
+    result = processor.parse_time("۱۰:۳۰ صبح")
+    assert isinstance(result, datetime.datetime)
+    assert result.hour == 10
+    assert result.minute == 30
+


### PR DESCRIPTION
## Summary
- test parse_time with Persian time string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406d9cebb4832f8ab0a7535402532f