### PR TITLE
Add monitoring README and Grafana dashboard

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,1 +1,36 @@
- 
+# Monitoring Stack
+
+This directory contains configuration files for Prometheus, Grafana and Alertmanager.
+
+## Running on Kubernetes
+
+1. Create the monitoring namespace:
+   ```bash
+   kubectl apply -f k8s/namespace.yaml
+   ```
+2. Deploy Prometheus, Grafana and exporters:
+   ```bash
+   kubectl apply -f k8s/prometheus.yaml
+   kubectl apply -f k8s/grafana.yaml
+   kubectl apply -f k8s/node-exporter.yaml
+   kubectl apply -f k8s/postgres-exporter.yaml
+   kubectl apply -f k8s/redis-exporter.yaml
+   kubectl apply -f k8s/kube-state-metrics.yaml
+   ```
+3. Apply alerting rules and Alertmanager:
+   ```bash
+   kubectl apply -f k8s/alertmanager.yaml
+   kubectl apply -f k8s/monitoring.yaml
+   ```
+4. Access Grafana via the service `grafana` in the `monitoring` namespace. Default credentials are defined in `k8s/grafana-secrets.yaml`.
+5. Import dashboards from `grafana_dashboards/` or use `grafana_dashboard.json` for a quick overview dashboard.
+
+## Configuration Files
+
+- `prometheus.yml` – Prometheus scrape configuration.
+- `alertmanager.yml` – Alert routing to Slack or other receivers.
+- `alert_rules.yml` – Collection of alerting rules for crawler components.
+- `grafana_dashboard.json` – Example Grafana dashboard definition.
+- `grafana_dashboards/` – Additional dashboards organised per component.
+
+

--- a/monitoring/grafana_dashboard.json
+++ b/monitoring/grafana_dashboard.json
@@ -1,1 +1,96 @@
- 
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Crawler Performance",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(crawler_requests_total[5m])", "legendFormat": "Requests/sec", "refId": "A" },
+        { "expr": "rate(crawler_errors_total[5m])", "legendFormat": "Errors/sec", "refId": "B" },
+        { "expr": "rate(crawler_flights_found_total[5m])", "legendFormat": "Flights/sec", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "title": "Response Times",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(crawler_request_duration_seconds_sum[5m]) / rate(crawler_request_duration_seconds_count[5m])", "legendFormat": "Avg", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, rate(crawler_request_duration_seconds_bucket[5m]))", "legendFormat": "95th %", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "title": "Queue Metrics",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "crawler_worker_queue_size", "legendFormat": "Queue Size", "refId": "A" },
+        { "expr": "rate(crawler_worker_tasks_processed_total[5m])", "legendFormat": "Tasks/sec", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "title": "Price Changes",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(crawler_price_changes_total[5m])", "legendFormat": "Changes/sec", "refId": "A" },
+        { "expr": "crawler_prediction_accuracy", "legendFormat": "Prediction Accuracy", "refId": "B" }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Crawler Performance",
+  "uid": "crawler-performance",
+  "version": 1,
+  "weekStart": ""
+}
+


### PR DESCRIPTION
## Summary
- document how to deploy monitoring stack in `monitoring/README.md`
- provide an example Grafana dashboard in `monitoring/grafana_dashboard.json`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find crawl4ai>=1.0.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68420c0a9a18832fb998a8937fa59d87