### PR TITLE
Add full site configurations

### DIFF
--- a/config/site_configs/alibaba.json
+++ b/config/site_configs/alibaba.json
@@ -1,1 +1,75 @@
- 
+{
+    "site_id": "alibaba",
+    "name": "Alibaba",
+    "search_url": "https://www.alibaba.ir/flight/search",
+    "persian_processing": {
+        "rtl_support": true,
+        "jalali_calendar": true,
+        "persian_numerals": true
+    },
+    "extraction_config": {
+        "search_form": {
+            "origin_field": "input[name=\"origin\"]",
+            "destination_field": "input[name=\"destination\"]",
+            "date_field": "input[name=\"departure_date\"]",
+            "passengers_field": "select[name=\"passengers\"]",
+            "class_field": "select[name=\"cabin_class\"]"
+        },
+        "results_parsing": {
+            "container": ".flight-item",
+            "price": ".price",
+            "airline": ".airline-name",
+            "duration": ".duration",
+            "departure_time": ".departure-time",
+            "arrival_time": ".arrival-time",
+            "flight_number": ".flight-number",
+            "seat_class": ".seat-class"
+        }
+    },
+    "data_validation": {
+        "required_fields": [
+            "airline",
+            "flight_number",
+            "departure_time",
+            "arrival_time",
+            "price",
+            "currency",
+            "seat_class",
+            "duration_minutes"
+        ],
+        "price_range": {
+            "min": 1000000,
+            "max": 100000000
+        },
+        "duration_range": {
+            "min": 30,
+            "max": 1440
+        }
+    },
+    "rate_limiting": {
+        "requests_per_second": 2,
+        "burst_limit": 5,
+        "cooldown_period": 60
+    },
+    "error_handling": {
+        "max_retries": 3,
+        "retry_delay": 5,
+        "circuit_breaker": {
+            "failure_threshold": 5,
+            "reset_timeout": 300
+        }
+    },
+    "monitoring": {
+        "metrics": [
+            "request_duration",
+            "success_rate",
+            "error_rate",
+            "flight_count",
+            "price_range"
+        ],
+        "alerts": {
+            "error_threshold": 0.1,
+            "latency_threshold": 30
+        }
+    }
+}

--- a/config/site_configs/book_charter.json
+++ b/config/site_configs/book_charter.json
@@ -1,1 +1,86 @@
- 
+{
+    "site_id": "book_charter",
+    "name": "Book Charter",
+    "search_url": "https://www.bookcharter.ir/flight-search",
+    "persian_processing": {
+        "rtl_support": true,
+        "jalali_calendar": true,
+        "persian_numerals": true
+    },
+    "extraction_config": {
+        "search_form": {
+            "origin_field": "input[name=\"origin\"]",
+            "destination_field": "input[name=\"destination\"]",
+            "date_field": "input[name=\"departure_date\"]",
+            "passengers_field": "select[name=\"passengers\"]",
+            "class_field": "select[name=\"cabin_class\"]",
+            "charter_type_field": "select[name=\"charter_type\"]"
+        },
+        "results_parsing": {
+            "container": ".charter-flight-result",
+            "price": ".price",
+            "airline": ".airline-name",
+            "duration": ".duration",
+            "departure_time": ".departure-time",
+            "arrival_time": ".arrival-time",
+            "flight_number": ".flight-number",
+            "seat_class": ".seat-class",
+            "charter_type": ".charter-type",
+            "available_seats": ".available-seats",
+            "aircraft_type": ".aircraft-type",
+            "charter_company": ".charter-company",
+            "charter_conditions": ".charter-conditions",
+            "payment_terms": ".payment-terms",
+            "cancellation_policy": ".cancellation-policy"
+        }
+    },
+    "data_validation": {
+        "required_fields": [
+            "airline",
+            "flight_number",
+            "departure_time",
+            "arrival_time",
+            "price",
+            "currency",
+            "seat_class",
+            "duration_minutes",
+            "charter_type",
+            "charter_company"
+        ],
+        "price_range": {
+            "min": 1000000,
+            "max": 100000000
+        },
+        "duration_range": {
+            "min": 30,
+            "max": 1440
+        }
+    },
+    "rate_limiting": {
+        "requests_per_second": 2,
+        "burst_limit": 5,
+        "cooldown_period": 60
+    },
+    "error_handling": {
+        "max_retries": 3,
+        "retry_delay": 5,
+        "circuit_breaker": {
+            "failure_threshold": 5,
+            "reset_timeout": 300
+        }
+    },
+    "monitoring": {
+        "metrics": [
+            "request_duration",
+            "success_rate",
+            "error_rate",
+            "flight_count",
+            "price_range",
+            "charter_availability"
+        ],
+        "alerts": {
+            "error_threshold": 0.1,
+            "latency_threshold": 30
+        }
+    }
+}

--- a/config/site_configs/flytoday.json
+++ b/config/site_configs/flytoday.json
@@ -1,1 +1,77 @@
- 
+{
+    "site_id": "flytoday",
+    "name": "Flytoday",
+    "search_url": "https://www.flytoday.ir/flight-search",
+    "persian_processing": {
+        "rtl_support": true,
+        "jalali_calendar": true,
+        "persian_numerals": true
+    },
+    "extraction_config": {
+        "search_form": {
+            "origin_field": "input[name=\"origin\"]",
+            "destination_field": "input[name=\"destination\"]",
+            "date_field": "input[name=\"departure_date\"]",
+            "passengers_field": "select[name=\"passengers\"]",
+            "class_field": "select[name=\"cabin_class\"]"
+        },
+        "results_parsing": {
+            "container": ".flight-result",
+            "price": ".price",
+            "airline": ".airline-name",
+            "duration": ".duration",
+            "departure_time": ".departure-time",
+            "arrival_time": ".arrival-time",
+            "flight_number": ".flight-number",
+            "seat_class": ".seat-class",
+            "available_seats": ".available-seats",
+            "aircraft_type": ".aircraft-type"
+        }
+    },
+    "data_validation": {
+        "required_fields": [
+            "airline",
+            "flight_number",
+            "departure_time",
+            "arrival_time",
+            "price",
+            "currency",
+            "seat_class",
+            "duration_minutes"
+        ],
+        "price_range": {
+            "min": 1000000,
+            "max": 100000000
+        },
+        "duration_range": {
+            "min": 30,
+            "max": 1440
+        }
+    },
+    "rate_limiting": {
+        "requests_per_second": 2,
+        "burst_limit": 5,
+        "cooldown_period": 60
+    },
+    "error_handling": {
+        "max_retries": 3,
+        "retry_delay": 5,
+        "circuit_breaker": {
+            "failure_threshold": 5,
+            "reset_timeout": 300
+        }
+    },
+    "monitoring": {
+        "metrics": [
+            "request_duration",
+            "success_rate",
+            "error_rate",
+            "flight_count",
+            "price_range"
+        ],
+        "alerts": {
+            "error_threshold": 0.1,
+            "latency_threshold": 30
+        }
+    }
+}

--- a/config/site_configs/parto_crs.json
+++ b/config/site_configs/parto_crs.json
@@ -1,1 +1,95 @@
- 
+{
+    "site_id": "parto_crs",
+    "name": "Parto CRS",
+    "search_url": "https://www.partocrs.com/b2b/flight-search",
+    "b2b_credentials": {
+        "username": "${PARTO_CRS_USERNAME}",
+        "password": "${PARTO_CRS_PASSWORD}"
+    },
+    "persian_processing": {
+        "rtl_support": true,
+        "jalali_calendar": true,
+        "persian_numerals": true
+    },
+    "extraction_config": {
+        "search_form": {
+            "origin_field": "input[name=\"origin\"]",
+            "destination_field": "input[name=\"destination\"]",
+            "date_field": "input[name=\"departure_date\"]",
+            "passengers_field": "select[name=\"passengers\"]",
+            "class_field": "select[name=\"cabin_class\"]",
+            "agency_code_field": "input[name=\"agency_code\"]",
+            "commission_rate_field": "input[name=\"commission_rate\"]"
+        },
+        "results_parsing": {
+            "container": ".flight-result",
+            "price": ".price",
+            "airline": ".airline-name",
+            "duration": ".duration",
+            "departure_time": ".departure-time",
+            "arrival_time": ".arrival-time",
+            "flight_number": ".flight-number",
+            "seat_class": ".seat-class",
+            "commission_info": ".commission-info",
+            "fare_rules": ".fare-rules",
+            "booking_class": ".booking-class",
+            "available_seats": ".available-seats",
+            "fare_basis": ".fare-basis",
+            "ticket_validity": ".ticket-validity"
+        }
+    },
+    "data_validation": {
+        "required_fields": [
+            "airline",
+            "flight_number",
+            "departure_time",
+            "arrival_time",
+            "price",
+            "currency",
+            "seat_class",
+            "duration_minutes",
+            "commission",
+            "fare_rules",
+            "booking_class"
+        ],
+        "price_range": {
+            "min": 1000000,
+            "max": 100000000
+        },
+        "duration_range": {
+            "min": 30,
+            "max": 1440
+        },
+        "commission_range": {
+            "min": 0,
+            "max": 100
+        }
+    },
+    "rate_limiting": {
+        "requests_per_second": 2,
+        "burst_limit": 5,
+        "cooldown_period": 60
+    },
+    "error_handling": {
+        "max_retries": 3,
+        "retry_delay": 5,
+        "circuit_breaker": {
+            "failure_threshold": 5,
+            "reset_timeout": 300
+        }
+    },
+    "monitoring": {
+        "metrics": [
+            "request_duration",
+            "success_rate",
+            "error_rate",
+            "flight_count",
+            "price_range",
+            "commission_range"
+        ],
+        "alerts": {
+            "error_threshold": 0.1,
+            "latency_threshold": 30
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fill missing configs for alibaba, book charter, flytoday and parto CRS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420be97e48832fb087126e86f348d3