### PR TITLE
Add adapter platform tests

### DIFF
--- a/tests/platform_tests/test_alibaba_adapter.py
+++ b/tests/platform_tests/test_alibaba_adapter.py
@@ -1,1 +1,77 @@
- 
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("crawl4ai") is None:
+    pytest.skip("crawl4ai not installed", allow_module_level=True)
+
+from site_crawlers import AlibabaCrawler
+
+class DummyRateLimiter:
+    async def wait_for_domain(self, domain):
+        pass
+    def check_rate_limit(self, domain):
+        return True
+    def get_wait_time(self, domain):
+        return 0
+
+class DummyMonitor:
+    async def track_request(self, domain, timestamp, success=True, error=None):
+        self.called = True
+
+class DummyErrorHandler:
+    async def can_make_request(self, domain):
+        return True
+    async def handle_error(self, domain, error):
+        self.error = error
+
+class DummyCrawler:
+    def __init__(self, html=""):
+        self._html = html
+    async def goto(self, url):
+        self.url = url
+    async def wait_for_selector(self, selector, timeout=10):
+        return True
+    async def content(self):
+        return self._html
+    async def execute_js(self, script, *args, **kwargs):
+        pass
+    async def screenshot(self, *args, **kwargs):
+        pass
+
+@pytest.fixture
+def sample_html():
+    return """
+    <div class='flight-list'>
+        <div class='flight-item'>
+            <span class='airline-name'>TestAir</span>
+            <span class='flight-number'>TA123</span>
+            <span class='departure-time'>08:00</span>
+            <span class='arrival-time'>09:30</span>
+            <span class='price'>1,000,000 ریال</span>
+            <span class='seat-class'>اکونومی</span>
+            <span class='duration'>90</span>
+        </div>
+    </div>
+    """
+
+@pytest.fixture
+def crawler(monkeypatch, sample_html):
+    monkeypatch.setattr('site_crawlers.AsyncWebCrawler', lambda config=None: DummyCrawler(sample_html))
+    monkeypatch.setattr('site_crawlers.BrowserConfig', lambda *a, **k: None)
+    crawler = AlibabaCrawler(DummyRateLimiter(), None, DummyMonitor(), DummyErrorHandler())
+    crawler.crawler = DummyCrawler(sample_html)
+    return crawler
+
+@pytest.mark.asyncio
+async def test_parse_search_results(crawler):
+    params = {
+        'origin': 'THR',
+        'destination': 'MHD',
+        'departure_date': '2024-01-01',
+        'passengers': 1,
+        'seat_class': 'economy'
+    }
+    results = await crawler.search_flights(params)
+    assert isinstance(results, list)
+    assert results[0]['airline'] == 'TestAir'
+    assert results[0]['flight_number'] == 'TA123'

--- a/tests/platform_tests/test_book_charter_724_adapter.py
+++ b/tests/platform_tests/test_book_charter_724_adapter.py
@@ -1,1 +1,55 @@
- 
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("crawl4ai") is None:
+    pytest.skip("crawl4ai not installed", allow_module_level=True)
+
+from site_crawlers import BookCharter724Crawler
+
+class DummyRateLimiter:
+    async def wait_for_domain(self, domain):
+        pass
+    def check_rate_limit(self, domain):
+        return True
+    def get_wait_time(self, domain):
+        return 0
+
+class DummyMonitor:
+    async def track_request(self, domain, timestamp, success=True, error=None):
+        self.called = True
+
+class DummyErrorHandler:
+    async def can_make_request(self, domain):
+        return True
+    async def handle_error(self, domain, error):
+        self.error = error
+
+class DummyCrawler:
+    async def goto(self, url):
+        self.url = url
+    async def wait_for_selector(self, selector, timeout=10):
+        return True
+    async def execute_js(self, script, *args, **kwargs):
+        pass
+    async def screenshot(self, *args, **kwargs):
+        pass
+
+@pytest.fixture
+def crawler(monkeypatch):
+    monkeypatch.setattr('site_crawlers.AsyncWebCrawler', lambda config=None: DummyCrawler())
+    monkeypatch.setattr('site_crawlers.BrowserConfig', lambda *a, **k: None)
+    crawler = BookCharter724Crawler(DummyRateLimiter(), None, DummyMonitor(), DummyErrorHandler())
+    crawler.crawler = DummyCrawler()
+    return crawler
+
+@pytest.mark.asyncio
+async def test_returns_empty_list(crawler):
+    params = {
+        'origin': 'THR',
+        'destination': 'MHD',
+        'departure_date': '2024-01-01',
+        'passengers': 1,
+        'seat_class': 'economy'
+    }
+    results = await crawler.search_flights(params)
+    assert results == []

--- a/tests/platform_tests/test_book_charter_adapter.py
+++ b/tests/platform_tests/test_book_charter_adapter.py
@@ -1,1 +1,55 @@
- 
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("crawl4ai") is None:
+    pytest.skip("crawl4ai not installed", allow_module_level=True)
+
+from site_crawlers import BookCharterCrawler
+
+class DummyRateLimiter:
+    async def wait_for_domain(self, domain):
+        pass
+    def check_rate_limit(self, domain):
+        return True
+    def get_wait_time(self, domain):
+        return 0
+
+class DummyMonitor:
+    async def track_request(self, domain, timestamp, success=True, error=None):
+        self.called = True
+
+class DummyErrorHandler:
+    async def can_make_request(self, domain):
+        return True
+    async def handle_error(self, domain, error):
+        self.error = error
+
+class DummyCrawler:
+    async def goto(self, url):
+        self.url = url
+    async def wait_for_selector(self, selector, timeout=10):
+        return True
+    async def execute_js(self, script, *args, **kwargs):
+        pass
+    async def screenshot(self, *args, **kwargs):
+        pass
+
+@pytest.fixture
+def crawler(monkeypatch):
+    monkeypatch.setattr('site_crawlers.AsyncWebCrawler', lambda config=None: DummyCrawler())
+    monkeypatch.setattr('site_crawlers.BrowserConfig', lambda *a, **k: None)
+    crawler = BookCharterCrawler(DummyRateLimiter(), None, DummyMonitor(), DummyErrorHandler())
+    crawler.crawler = DummyCrawler()
+    return crawler
+
+@pytest.mark.asyncio
+async def test_returns_empty_list(crawler):
+    params = {
+        'origin': 'THR',
+        'destination': 'MHD',
+        'departure_date': '2024-01-01',
+        'passengers': 1,
+        'seat_class': 'economy'
+    }
+    results = await crawler.search_flights(params)
+    assert results == []

--- a/tests/platform_tests/test_flytoday_adapter.py
+++ b/tests/platform_tests/test_flytoday_adapter.py
@@ -1,1 +1,58 @@
- 
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("crawl4ai") is None:
+    pytest.skip("crawl4ai not installed", allow_module_level=True)
+
+from site_crawlers import FlytodayCrawler
+
+class DummyRateLimiter:
+    async def wait_for_domain(self, domain):
+        pass
+    def check_rate_limit(self, domain):
+        return True
+    def get_wait_time(self, domain):
+        return 0
+
+class DummyMonitor:
+    async def track_request(self, domain, timestamp, success=True, error=None):
+        self.called = True
+
+class DummyErrorHandler:
+    async def can_make_request(self, domain):
+        return True
+    async def handle_error(self, domain, error):
+        self.error = error
+
+class DummyCrawler:
+    async def goto(self, url):
+        self.url = url
+    async def wait_for_selector(self, selector, timeout=10):
+        return True
+    async def content(self):
+        return ""
+    async def execute_js(self, script, *args, **kwargs):
+        pass
+    async def screenshot(self, *args, **kwargs):
+        pass
+
+@pytest.fixture
+def crawler(monkeypatch):
+    monkeypatch.setattr('site_crawlers.AsyncWebCrawler', lambda config=None: DummyCrawler())
+    monkeypatch.setattr('site_crawlers.BrowserConfig', lambda *a, **k: None)
+    crawler = FlytodayCrawler(DummyRateLimiter(), None, DummyMonitor(), DummyErrorHandler())
+    crawler.crawler = DummyCrawler()
+    return crawler
+
+@pytest.mark.asyncio
+async def test_search_flights_returns_dummy(crawler):
+    params = {
+        'origin': 'THR',
+        'destination': 'MHD',
+        'departure_date': '2024-01-01',
+        'passengers': 1,
+        'seat_class': 'economy'
+    }
+    results = await crawler.search_flights(params)
+    assert isinstance(results, list)
+    assert results and 'flight_number' in results[0]

--- a/tests/platform_tests/test_mahan_air_adapter.py
+++ b/tests/platform_tests/test_mahan_air_adapter.py
@@ -1,1 +1,121 @@
- 
+import types
+import sys
+import pytest
+
+# Stub external dependencies so the adapter module can be imported without the real packages
+sys.modules['bs4'] = types.ModuleType('bs4')
+sys.modules['bs4'].BeautifulSoup = lambda *a, **k: None
+sys.modules['playwright'] = types.ModuleType('playwright')
+sys.modules['playwright.async_api'] = types.ModuleType('playwright.async_api')
+sys.modules['playwright.async_api'].TimeoutError = Exception
+
+utils_ptp = types.ModuleType('utils.persian_text_processor')
+class DummyPersianProcessor:
+    def process_text(self, text):
+        return text
+    def process_date(self, text):
+        return text
+    def process_price(self, text):
+        return 100000
+utils_ptp.PersianTextProcessor = DummyPersianProcessor
+sys.modules['utils.persian_text_processor'] = utils_ptp
+sys.modules['utils.rate_limiter'] = types.ModuleType('utils.rate_limiter')
+sys.modules['utils.rate_limiter'].RateLimiter = lambda *a, **k: None
+sys.modules['utils.error_handler'] = types.ModuleType('utils.error_handler')
+sys.modules['utils.error_handler'].ErrorHandler = lambda *a, **k: None
+utils_mon = types.ModuleType('utils.monitoring')
+class DummyMon:
+    def __init__(self, *a, **k):
+        pass
+    def record_success(self):
+        pass
+    def record_error(self):
+        pass
+utils_mon.Monitoring = DummyMon
+sys.modules['utils.monitoring'] = utils_mon
+base_mod = types.ModuleType('adapters.base_adapters.persian_airline_crawler')
+class PersianAirlineCrawler:
+    def __init__(self, config):
+        self.config = config
+        self.page = None
+base_mod.PersianAirlineCrawler = PersianAirlineCrawler
+sys.modules['adapters.base_adapters.persian_airline_crawler'] = base_mod
+
+from adapters.site_adapters.iranian_airlines.mahan_air_adapter import MahanAirAdapter
+
+@pytest.fixture
+def sample_config():
+    fields = {
+        'airline': '.airline',
+        'flight_number': '.number',
+        'departure_time': '.dep',
+        'arrival_time': '.arr',
+        'duration': '.dur',
+        'price': '.price',
+        'seat_class': '.seat',
+        'fare_conditions': '.unused',
+        'available_seats': '.unused',
+        'aircraft_type': '.unused',
+        'baggage_allowance': '.unused',
+        'meal_service': '.unused',
+        'special_services': '.unused',
+        'refund_policy': '.unused',
+        'change_policy': '.unused',
+        'fare_rules': '.unused',
+        'booking_class': '.unused',
+        'fare_basis': '.unused',
+        'ticket_validity': '.unused',
+        'miles_earned': '.unused',
+        'miles_required': '.unused',
+        'promotion_code': '.unused',
+        'special_offers': '.unused'
+    }
+    return {
+        'search_url': 'https://example.com',
+        'extraction_config': {
+            'search_form': {},
+            'results_parsing': fields
+        },
+        'data_validation': {
+            'required_fields': ['airline','flight_number','departure_time','arrival_time','price','currency','seat_class','duration_minutes'],
+            'price_range': {'min': 1, 'max': 1000000},
+            'duration_range': {'min': 30, 'max': 600}
+        },
+        'rate_limiting': {'requests_per_second': 1, 'burst_limit': 1, 'cooldown_period': 1},
+        'error_handling': {'max_retries': 1, 'retry_delay': 1, 'circuit_breaker': {}},
+        'monitoring': {}
+    }
+
+@pytest.fixture
+def adapter(sample_config):
+    return MahanAirAdapter(sample_config)
+
+def test_validate_search_params(adapter):
+    params = {
+        'origin': 'THR',
+        'destination': 'MHD',
+        'departure_date': '2024-01-01',
+        'passengers': 1,
+        'seat_class': 'economy'
+    }
+    # Should not raise
+    adapter._validate_search_params(params)
+    params.pop('origin')
+    with pytest.raises(ValueError):
+        adapter._validate_search_params(params)
+
+def test_validate_flight_data(adapter):
+    flight = {
+        'airline': 'Mahan',
+        'flight_number': 'W5123',
+        'departure_time': '08:00',
+        'arrival_time': '09:00',
+        'price': 200000,
+        'currency': 'IRR',
+        'seat_class': 'economy',
+        'duration_minutes': 60
+    }
+    results = adapter._validate_flight_data([flight])
+    assert results == [flight]
+    flight['price'] = 0
+    assert adapter._validate_flight_data([flight]) == []


### PR DESCRIPTION
## Summary
- add tests for Flytoday, Alibaba, BookCharter724 and BookCharter crawlers
- add tests for Mahan Air adapter with patched dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68420be83d2c832f9fa38d7d6b15db0d