### PR TITLE
Implement dummy flight responses for all crawlers

### DIFF
--- a/site_crawlers.py
+++ b/site_crawlers.py
@@ -340,9 +340,11 @@ class Mz724Crawler(BaseSiteCrawler):
                 if wait_time:
                     await asyncio.sleep(wait_time)
             await self.crawler.goto(self.base_url)
-            # TODO: implement form submission and parsing
+            flights = await self._return_dummy_flights(search_params)
+
             await self._take_screenshot("search_results")
-            return []
+            await self.monitor.track_request(self.domain, start_time.timestamp())
+            return flights
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
@@ -367,9 +369,11 @@ class PartoCRSCrawler(BaseSiteCrawler):
                 if wait_time:
                     await asyncio.sleep(wait_time)
             await self.crawler.goto(self.base_url)
-            # TODO: implement form submission and parsing
+            flights = await self._return_dummy_flights(search_params)
+
             await self._take_screenshot("search_results")
-            return []
+            await self.monitor.track_request(self.domain, start_time.timestamp())
+            return flights
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
@@ -394,9 +398,11 @@ class PartoTicketCrawler(BaseSiteCrawler):
                 if wait_time:
                     await asyncio.sleep(wait_time)
             await self.crawler.goto(self.base_url)
-            # TODO: implement form submission and parsing
+            flights = await self._return_dummy_flights(search_params)
+
             await self._take_screenshot("search_results")
-            return []
+            await self.monitor.track_request(self.domain, start_time.timestamp())
+            return flights
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
@@ -421,9 +427,11 @@ class BookCharter724Crawler(BaseSiteCrawler):
                 if wait_time:
                     await asyncio.sleep(wait_time)
             await self.crawler.goto(self.base_url)
-            # TODO: implement form submission and parsing
+            flights = await self._return_dummy_flights(search_params)
+
             await self._take_screenshot("search_results")
-            return []
+            await self.monitor.track_request(self.domain, start_time.timestamp())
+            return flights
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
@@ -448,9 +456,11 @@ class BookCharterCrawler(BaseSiteCrawler):
                 if wait_time:
                     await asyncio.sleep(wait_time)
             await self.crawler.goto(self.base_url)
-            # TODO: implement form submission and parsing
+            flights = await self._return_dummy_flights(search_params)
+
             await self._take_screenshot("search_results")
-            return []
+            await self.monitor.track_request(self.domain, start_time.timestamp())
+            return flights
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)


### PR DESCRIPTION
## Summary
- make crawler classes always return dummy flights
- remove TODO placeholders in `site_crawlers`

## Testing
- `pip install -r /tmp/reqs.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420ef8dd04832f8c914c9b2344f9cf