### PR TITLE
Fix dependency conflicts with crawl4ai

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,10 +44,10 @@ alembic==1.12.1
 celery>=5.3.0
 beautifulsoup4>=4.12.0
 python-multipart>=0.0.6
-googletrans==4.0.0rc1
+googletrans>=4.0.2
 langdetect==1.0.9
 joblib==1.3.2
-playwright==1.40.0
+playwright>=1.49.0
 aiofiles>=23.2.1
 python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4


### PR DESCRIPTION
## Summary
- update Playwright requirement to 1.49+
- update Googletrans to 4.0.2 so it works with httpx 0.27+

## Testing
- `pytest -q` *(fails: test_crawl_all_sites)*

------
https://chatgpt.com/codex/tasks/task_e_684447dfd5c8832f9e104f0c8be75bc1