### PR TITLE
Fix crawler runtime errors and JSON caching

### DIFF
--- a/crawlers/factories/crawler_factory.py
+++ b/crawlers/factories/crawler_factory.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Any
 import json
-from crawl4ai import AsyncWebCrawler, BrowserConfig
+from local_crawler import AsyncWebCrawler, BrowserConfig
 from bs4 import BeautifulSoup
 from playwright.async_api import async_playwright, Browser, Page
 

--- a/data_manager.py
+++ b/data_manager.py
@@ -165,7 +165,7 @@ class DataManager:
             self.redis.setex(
                 key,
                 config.CACHE_TTL,
-                json.dumps(results)
+                json.dumps(results, default=str)
             )
             
         except Exception as e:
@@ -348,6 +348,9 @@ class DataManager:
 
             for _, site_flights in flights.items():
                 for flight_data in site_flights:
+                    if not all(k in flight_data for k in ("airline", "flight_number", "origin", "destination", "departure_time", "arrival_time", "price", "currency", "seat_class", "duration_minutes", "source_url")):
+                        logger.error("Missing required flight fields")
+                        continue
                     flight_id = (
                         f"{flight_data['airline']}_{flight_data['flight_number']}"
                         f"_{flight_data['origin']}_{flight_data['destination']}"
@@ -414,7 +417,7 @@ class DataManager:
             self.redis.setex(
                 f"search:{search_key}",
                 timedelta(hours=1),  # Cache for 1 hour
-                json.dumps(results)
+                json.dumps(results, default=str)
             )
         except Exception as e:
             logger.error(f"Error caching search results: {e}")

--- a/local_crawler.py
+++ b/local_crawler.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from typing import Optional
+from playwright.async_api import async_playwright, Page
+
+@dataclass
+class BrowserConfig:
+    headless: bool = True
+    viewport_width: int = 1920
+    viewport_height: int = 1080
+    timeout: int = 30000
+
+
+@dataclass
+class CrawlerRunConfig:
+    cache_mode: Optional[object] = None
+    timeout: int = 30000
+    wait_for_timeout: int = 15000
+    js_only: bool = False
+    screenshot: bool = False
+    verbose: bool = False
+
+class AsyncWebCrawler:
+    def __init__(self, config: BrowserConfig | None = None):
+        self.config = config or BrowserConfig()
+        self._playwright = None
+        self._browser = None
+        self._context = None
+        self.page: Optional[Page] = None
+
+    async def _ensure_browser(self):
+        if self.page:
+            return
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=self.config.headless)
+        self._context = await self._browser.new_context(
+            viewport={"width": self.config.viewport_width, "height": self.config.viewport_height}
+        )
+        self.page = await self._context.new_page()
+
+    async def goto(self, url: str):
+        await self._ensure_browser()
+        await self.page.goto(url, timeout=self.config.timeout)
+
+    async def wait_for_selector(self, selector: str, timeout: int = 10):
+        await self._ensure_browser()
+        await self.page.wait_for_selector(selector, timeout=timeout * 1000)
+        return True
+
+    async def content(self) -> str:
+        await self._ensure_browser()
+        return await self.page.content()
+
+    async def execute_js(self, script: str, *args):
+        await self._ensure_browser()
+        return await self.page.evaluate(script, *args)
+
+    async def screenshot(self, path: str):
+        await self._ensure_browser()
+        await self.page.screenshot(path=path)
+
+    async def close(self):
+        if self._context:
+            await self._context.close()
+        if self._browser:
+            await self._browser.close()
+        if self._playwright:
+            await self._playwright.stop()
+        self.page = None

--- a/main_crawler.py
+++ b/main_crawler.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import redis
 import psycopg2
-from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
-from crawl4ai.extraction_strategy import LLMExtractionStrategy
+from local_crawler import BrowserConfig, CrawlerRunConfig
 from hazm import Normalizer
 from persian_tools import digits
 import jdatetime

--- a/site_crawlers.py
+++ b/site_crawlers.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import List, Dict, Optional, Any
 from datetime import datetime
-from crawl4ai import AsyncWebCrawler, BrowserConfig
+from local_crawler import AsyncWebCrawler, BrowserConfig
 try:
     from crawl4ai.cache_mode import CacheMode
 except Exception:  # pragma: no cover - optional dependency

--- a/stealth_crawler.py
+++ b/stealth_crawler.py
@@ -3,7 +3,7 @@ import os
 import inspect
 from typing import Optional, List, Tuple, Dict, Any
 from dataclasses import dataclass
-from crawl4ai import BrowserConfig
+from local_crawler import BrowserConfig
 import asyncio
 import time
 from config import config


### PR DESCRIPTION
## Summary
- replace crawl4ai dependency with a local Playwright-based AsyncWebCrawler
- fix imports to use the new crawler
- convert datetimes when caching search results
- skip storing flights that lack essential fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684466b9a3e8832fb4ffbbfd1a53175c