### PR TITLE
Fix AsyncWebCrawler missing navigate method

### DIFF
--- a/local_crawler.py
+++ b/local_crawler.py
@@ -41,6 +41,10 @@ class AsyncWebCrawler:
         await self._ensure_browser()
         await self.page.goto(url, timeout=self.config.timeout)
 
+    async def navigate(self, url: str):
+        """Navigate to the given URL. Alias for ``goto`` for backward compatibility."""
+        await self.goto(url)
+
     async def wait_for_selector(self, selector: str, timeout: int = 10):
         await self._ensure_browser()
         await self.page.wait_for_selector(selector, timeout=timeout * 1000)


### PR DESCRIPTION
## Summary
- add `navigate` wrapper to `AsyncWebCrawler`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68446c072b94832f9dd754577b5f3654