### PR TITLE
Add debug mode logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ DB_USER=crawler
 DB_PASSWORD=secure_password
 REDIS_HOST=localhost
 REDIS_PORT=6379
+DEBUG_MODE=false
 ```
 
 2. Update the configuration in `config.py` as needed.
+3. Set `DEBUG_MODE=true` to enable verbose logging during development.
 
 ## Usage | استفاده
 

--- a/config.py
+++ b/config.py
@@ -57,7 +57,7 @@ class CrawlerConfig:
 @dataclass
 class MonitoringConfig:
     ENABLED: bool = True
-    LOG_LEVEL: str = 'INFO'
+    LOG_LEVEL: str = os.getenv('LOG_LEVEL', 'INFO')
     METRICS_PORT: int = 9090
     HEALTH_CHECK_PORT: int = 8000
     LOG_FILE: str = 'flight_crawler.log'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - DATABASE_URL=postgresql://crawler:secure_password@postgres:5432/flight_data
       - REDIS_URL=redis://redis:6379/0
       - LOG_LEVEL=INFO
+      - DEBUG_MODE=false
       - CRAWLER_TIMEOUT=30
       - CRAWLER_CONCURRENCY=3
       - CRAWLER_RETRY_ATTEMPTS=3

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import logging
 import asyncio
+import os
 from typing import Dict, List, Optional
 from datetime import datetime
 from fastapi import FastAPI, HTTPException, WebSocket, Header, Query
@@ -15,8 +16,12 @@ from ml_predictor import FlightPricePredictor
 from multilingual_processor import MultilingualProcessor
 
 # Configure logging
+debug_mode = os.getenv("DEBUG_MODE", "0").lower() in ("1", "true", "yes")
+log_level = logging.DEBUG if debug_mode else getattr(
+    logging, config.MONITORING.LOG_LEVEL.upper(), logging.INFO
+)
 logging.basicConfig(
-    level=config.MONITORING.LOG_LEVEL,
+    level=log_level,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)

--- a/startup.py
+++ b/startup.py
@@ -1,9 +1,12 @@
 import asyncio
 import logging
+import os
 from main_crawler import IranianFlightCrawler
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+debug_mode = os.getenv("DEBUG_MODE", "0").lower() in ("1", "true", "yes")
+level = logging.DEBUG if debug_mode else logging.INFO
+logging.basicConfig(level=level)
 logger = logging.getLogger(__name__)
 
 async def test_basic_functionality():


### PR DESCRIPTION
## Summary
- configure logging level from environment variable
- allow DEBUG_MODE env var to enable debug logging
- document DEBUG_MODE in readme
- expose DEBUG_MODE in docker-compose

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68446d3429e0832f9c44b0b5b61ef029