### PR TITLE
Fix passenger defaults for crawlers

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,6 +56,8 @@ class SearchRequest(BaseModel):
     origin: str
     destination: str
     date: str
+    passengers: int = 1
+    seat_class: str = "economy"
 
 class SearchResponse(BaseModel):
     flights: List[Dict]
@@ -98,6 +100,8 @@ async def search_flights(request: SearchRequest, accept_language: str = Header("
                 "origin": request.origin,
                 "destination": request.destination,
                 "departure_date": request.date,
+                "passengers": request.passengers,
+                "seat_class": request.seat_class,
             }
         )
         

--- a/main_crawler.py
+++ b/main_crawler.py
@@ -116,6 +116,10 @@ class IranianFlightCrawler:
     async def crawl_all_sites(self, search_params: Dict) -> List[Dict]:
         """Orchestrate crawling across all three sites"""
         try:
+            # Ensure required parameters have defaults
+            search_params.setdefault("passengers", 1)
+            search_params.setdefault("seat_class", "economy")
+
             # Check cache first
             cached_results = self.data_manager.get_cached_results(search_params)
             if cached_results:


### PR DESCRIPTION
## Summary
- add passengers and seat_class fields to search request
- provide defaults to missing crawler parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langdetect')*

------
https://chatgpt.com/codex/tasks/task_e_68454c92de34832f9af66d56b36e9bd7