### PR TITLE
Add single-site crawling and stats reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ tail -f flight_crawler.log
 ```bash
 python main.py
 ```
+
+4. Crawl a single website directly:
+```python
+from main_crawler import IranianFlightCrawler
+import asyncio
+
+crawler = IranianFlightCrawler()
+flights = asyncio.run(
+    crawler.crawl_site(
+        "alibaba.ir",
+        {"origin": "THR", "destination": "MHD", "departure_date": "2024-01-01"}
+    )
+)
+print(f"Found {len(flights)} flights")
+```
 Open `http://localhost:8000/ui` in your browser to access the control panel.
 
 ## User Guide | راهنمای کاربر

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,3 +18,21 @@ async def test_crawl_all_sites(monkeypatch):
     results = await crawler.crawl_all_sites({"origin":"THR","destination":"MHD","departure_date":"2024-01-01","passengers":1,"seat_class":"economy"})
     assert isinstance(results, list)
     assert results[0]["flight_number"] == "XX123"
+
+
+@pytest.mark.asyncio
+async def test_crawl_single_site(monkeypatch):
+    crawler = IranianFlightCrawler()
+    crawler.crawlers["flytoday.ir"] = DummyCrawler()
+    result = await crawler.crawl_site(
+        "flytoday.ir",
+        {
+            "origin": "THR",
+            "destination": "MHD",
+            "departure_date": "2024-01-01",
+            "passengers": 1,
+            "seat_class": "economy",
+        },
+    )
+    assert isinstance(result, list)
+    assert result[0]["flight_number"] == "XX123"


### PR DESCRIPTION
## Summary
- enable crawling a single site via `crawl_site`
- add method `reset_stats` for monitoring cleanup
- document single-site usage in README
- test single-site crawling

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454dc14094832f95739edc51e85010