### PR TITLE
Add crawled data tab

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -48,15 +48,17 @@ function fetchCrawled(limit: number) {
 export default function Page() {
   const { origin, destination, date, setOrigin, setDestination, setDate } = useSearchStore();
   const [priceRows, setPriceRows] = useState<PriceRow[]>([]);
+  const [activeTab, setActiveTab] = useState<'search' | 'crawled'>('search');
   const { data: flights = [], refetch, isFetching } = useQuery({
     queryKey: ['flights', origin, destination, date],
     queryFn: () => fetchFlights(origin, destination, date),
     enabled: false
   });
 
-  const { data: crawled = [] } = useQuery<CrawledFlight[]>({
-    queryKey: ['crawled'],
-    queryFn: () => fetchCrawled(20),
+  const { data: crawled = [], refetch: refetchCrawled } = useQuery<CrawledFlight[]>({
+    queryKey: ['crawled', activeTab],
+    queryFn: () => fetchCrawled(1000),
+    enabled: activeTab === 'crawled'
   });
 
   const handleMultiSearch = async (legs: Leg[]) => {
@@ -71,48 +73,68 @@ export default function Page() {
     <main className="max-w-xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-bold mb-4 text-center">جستجوی پرواز</h1>
       <CrawlerStatusMonitor />
-      <div className="space-y-2">
-        <input className="w-full p-2 border" placeholder="مبدا" value={origin} onChange={(e) => setOrigin(e.target.value)} />
-        <input className="w-full p-2 border" placeholder="مقصد" value={destination} onChange={(e) => setDestination(e.target.value)} />
-        <input type="date" className="w-full p-2 border" value={date} onChange={(e) => setDate(e.target.value)} />
-        <button className="w-full bg-blue-600 text-white p-2" onClick={() => refetch()} disabled={isFetching}>جستجو</button>
+      <div className="flex space-x-2 rtl:space-x-reverse my-4">
+        <button
+          className={`flex-1 p-2 border ${activeTab === 'search' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+          onClick={() => setActiveTab('search')}
+          data-testid="tab-search"
+        >
+          جستجو
+        </button>
+        <button
+          className={`flex-1 p-2 border ${activeTab === 'crawled' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+          onClick={() => { setActiveTab('crawled'); refetchCrawled(); }}
+          data-testid="tab-crawled"
+        >
+          داده‌های خزیده‌شده
+        </button>
       </div>
-      <div className="mt-4">
-        {isFetching ? 'در حال دریافت...' : (
-          flights.length ? (
-            <table className="w-full border">
-              <thead>
-                <tr>
-                  <th className="border p-1">شماره پرواز</th>
-                  <th className="border p-1">مبدا</th>
-                  <th className="border p-1">مقصد</th>
-                  <th className="border p-1">تاریخ</th>
-                  <th className="border p-1">قیمت</th>
-                </tr>
-              </thead>
-              <tbody>
-                {flights.map((f: Flight) => (
-                  <tr key={f.flight_number} className="text-center">
-                    <td className="border p-1">{f.flight_number}</td>
-                    <td className="border p-1">{f.origin}</td>
-                    <td className="border p-1">{f.destination}</td>
-                    <td className="border p-1">{f.date}</td>
-                    <td className="border p-1">{f.price}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          ) : 'نتیجه‌ای یافت نشد'
-        )}
-      </div>
-      <div className="mt-8">
-        <MultiCitySearch onSearch={handleMultiSearch} />
-        <PriceComparisonGrid rows={priceRows} />
-      </div>
-      <div className="mt-8">
-        <h2 className="text-lg font-bold mb-2">آخرین داده‌های خزیده‌شده</h2>
-        <CrawledDataGrid flights={crawled} />
-      </div>
+      {activeTab === 'search' ? (
+        <>
+          <div className="space-y-2">
+            <input className="w-full p-2 border" placeholder="مبدا" value={origin} onChange={(e) => setOrigin(e.target.value)} />
+            <input className="w-full p-2 border" placeholder="مقصد" value={destination} onChange={(e) => setDestination(e.target.value)} />
+            <input type="date" className="w-full p-2 border" value={date} onChange={(e) => setDate(e.target.value)} />
+            <button className="w-full bg-blue-600 text-white p-2" onClick={() => refetch()} disabled={isFetching}>جستجو</button>
+          </div>
+          <div className="mt-4">
+            {isFetching ? 'در حال دریافت...' : (
+              flights.length ? (
+                <table className="w-full border">
+                  <thead>
+                    <tr>
+                      <th className="border p-1">شماره پرواز</th>
+                      <th className="border p-1">مبدا</th>
+                      <th className="border p-1">مقصد</th>
+                      <th className="border p-1">تاریخ</th>
+                      <th className="border p-1">قیمت</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {flights.map((f: Flight) => (
+                      <tr key={f.flight_number} className="text-center">
+                        <td className="border p-1">{f.flight_number}</td>
+                        <td className="border p-1">{f.origin}</td>
+                        <td className="border p-1">{f.destination}</td>
+                        <td className="border p-1">{f.date}</td>
+                        <td className="border p-1">{f.price}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : 'نتیجه‌ای یافت نشد'
+            )}
+          </div>
+          <div className="mt-8">
+            <MultiCitySearch onSearch={handleMultiSearch} />
+            <PriceComparisonGrid rows={priceRows} />
+          </div>
+        </>
+      ) : (
+        <div className="mt-8" data-testid="crawled-tab">
+          <CrawledDataGrid flights={crawled} />
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show Search/Crawled tabs in Next.js UI
- fetch all crawled flight data when viewing the new tab
- unit tests pass

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684589c5cbfc832f93f175c8ed8bd4fb