### PR TITLE
Add BI pages

### DIFF
--- a/frontend/__tests__/site-bi.test.tsx
+++ b/frontend/__tests__/site-bi.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import SiteBIMetrics from '../app/components/SiteBIMetrics';
+
+test('renders business intelligence metrics', () => {
+  const data = {
+    site: 'demo',
+    base_url: 'https://demo',
+    url_accessible: true,
+    http_status: 200,
+    response_time: 0.1,
+    circuit_breaker_open: false,
+    rate_limited: false,
+    error_count_last_hour: 1,
+    success_count_last_hour: 5,
+  };
+  render(<SiteBIMetrics data={data} />);
+  expect(screen.getByText('https://demo')).toBeInTheDocument();
+  expect(screen.getByText('200')).toBeInTheDocument();
+});

--- a/frontend/app/components/SiteBIMetrics.tsx
+++ b/frontend/app/components/SiteBIMetrics.tsx
@@ -1,0 +1,56 @@
+'use client';
+import React from 'react';
+
+interface SiteHealth {
+  site: string;
+  base_url: string;
+  url_accessible?: boolean;
+  http_status?: number;
+  response_time?: number | null;
+  circuit_breaker_open?: boolean;
+  rate_limited?: boolean;
+  error_count_last_hour?: number;
+  success_count_last_hour?: number;
+}
+
+export default function SiteBIMetrics({ data }: { data: SiteHealth }) {
+  if (!data) return null;
+  return (
+    <table className="w-full border" data-testid="site-bi-table">
+      <tbody>
+        <tr>
+          <td className="border p-1">URL</td>
+          <td className="border p-1">{data.base_url}</td>
+        </tr>
+        <tr>
+          <td className="border p-1">Accessible</td>
+          <td className="border p-1">{data.url_accessible ? 'yes' : 'no'}</td>
+        </tr>
+        <tr>
+          <td className="border p-1">Status</td>
+          <td className="border p-1">{data.http_status ?? '-'}</td>
+        </tr>
+        <tr>
+          <td className="border p-1">Response Time</td>
+          <td className="border p-1">{data.response_time ?? '-'}</td>
+        </tr>
+        <tr>
+          <td className="border p-1">Circuit Breaker</td>
+          <td className="border p-1">{data.circuit_breaker_open ? 'open' : 'closed'}</td>
+        </tr>
+        <tr>
+          <td className="border p-1">Rate Limited</td>
+          <td className="border p-1">{data.rate_limited ? 'yes' : 'no'}</td>
+        </tr>
+        <tr>
+          <td className="border p-1">Errors Last Hour</td>
+          <td className="border p-1">{data.error_count_last_hour}</td>
+        </tr>
+        <tr>
+          <td className="border p-1">Success Last Hour</td>
+          <td className="border p-1">{data.success_count_last_hour}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/app/sites/[site]/page.tsx
+++ b/frontend/app/sites/[site]/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import SiteBIMetrics from '../../components/SiteBIMetrics';
+
+export default function SitePage({ params }: { params: { site: string } }) {
+  const { site } = params;
+  const [data, setData] = useState<any | null>(null);
+  useEffect(() => {
+    fetch(`/api/v1/sites/${site}/health`)
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, [site]);
+
+  return (
+    <main className="max-w-xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center">{site} گزارش</h1>
+      {data ? <SiteBIMetrics data={data} /> : 'در حال بارگذاری...'}
+    </main>
+  );
+}

--- a/frontend/app/sites/page.tsx
+++ b/frontend/app/sites/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function SitesIndex() {
+  const [sites, setSites] = useState<string[]>([]);
+  useEffect(() => {
+    fetch('/api/v1/sites/status')
+      .then((r) => r.json())
+      .then((d) => setSites(Object.keys(d.sites || {})));
+  }, []);
+
+  return (
+    <main className="max-w-xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center">Business Intelligence</h1>
+      <ul className="list-disc pl-4">
+        {sites.map((s) => (
+          <li key={s}>
+            <Link href={`/sites/${s}`}>{s}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- implement business intelligence pages
- expose site BI metrics page at `/sites/[site]`
- list BI pages under `/sites`
- add SiteBIMetrics component
- test new component

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bacdd518832fb050ec612ca7c0a4