### PR TITLE
Implement ProductionURLValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ DEBUG_MODE=false
 
 2. Update the configuration in `config.py` as needed.
 3. Set `DEBUG_MODE=true` to enable verbose logging during development.
+4. Validate target websites before running crawlers:
+```bash
+python -m production_url_validator
+```
 
 ## Usage | استفاده
 

--- a/config.py
+++ b/config.py
@@ -8,6 +8,20 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
+# Production site endpoints used for validation
+PRODUCTION_SITES = {
+    "flytoday": {
+        "base_url": "https://www.flytoday.ir",
+        "search_endpoint": "/flight/search",
+        "crawler_type": "javascript_heavy",
+    },
+    "alibaba": {
+        "base_url": "https://www.alibaba.ir",
+        "search_endpoint": "/flight/search",
+        "crawler_type": "javascript_heavy",
+    },
+}
+
 @dataclass
 class DatabaseConfig:
     HOST: str = os.getenv('DB_HOST', 'localhost')
@@ -146,4 +160,4 @@ class Config:
 config = Config()
 
 # Export configuration
-__all__ = ['config'] 
+__all__ = ['config', 'PRODUCTION_SITES']

--- a/production_url_validator.py
+++ b/production_url_validator.py
@@ -1,0 +1,45 @@
+import aiohttp
+from urllib.robotparser import RobotFileParser
+from typing import Dict
+from config import PRODUCTION_SITES
+
+class ProductionURLValidator:
+    """Validates and verifies real website URLs before crawling."""
+
+    async def _check_connectivity(self, url: str) -> bool:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=10) as resp:
+                    return resp.status < 400
+        except Exception:
+            return False
+
+    async def _check_robots(self, base_url: str) -> bool:
+        robots_url = base_url.rstrip('/') + '/robots.txt'
+        parser = RobotFileParser()
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(robots_url, timeout=10) as resp:
+                    if resp.status != 200:
+                        return True
+                    text = await resp.text()
+            parser.parse(text.splitlines())
+            return parser.can_fetch('*', '/')
+        except Exception:
+            return True
+
+    async def validate_target_urls(self) -> Dict[str, bool]:
+        results: Dict[str, bool] = {}
+        for name, cfg in PRODUCTION_SITES.items():
+            base_url = cfg.get('base_url')
+            ok = await self._check_connectivity(base_url)
+            robots_ok = await self._check_robots(base_url)
+            results[name] = ok and robots_ok
+        return results
+
+if __name__ == '__main__':
+    import asyncio
+    validator = ProductionURLValidator()
+    report = asyncio.run(validator.validate_target_urls())
+    for site, status in report.items():
+        print(f'{site}: {"ok" if status else "failed"}')


### PR DESCRIPTION
## Summary
- add real endpoints for Flytoday and Alibaba in configuration
- create ProductionURLValidator for connectivity and robots.txt checks
- document how to run the validator

## Testing
- `python production_url_validator.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68467a07b2f8832f8d8a2c6813870dec