### PR TITLE
Add production setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A sophisticated web crawler system for Iranian flight booking websites with inte
 - [Usage](#usage)
 - [User Guide](#user-guide)
 - [Developer Guide](#developer-guide)
+- [Production Setup](#production-setup)
 - [Adding New Websites](#adding-new-websites)
 
 ## Overview | مرور کلی
@@ -178,6 +179,22 @@ FlightioCrawler/
 5. **Flight Monitoring System** (`flight_monitor.py`)
    - Runs continuous crawling loops
    - Platform-specific intervals
+
+## Production Setup | راه‌اندازی محیط تولید
+
+For real-world deployments the project includes several production utilities:
+
+- **ProductionURLValidator** – verifies target websites individually and checks
+  HTTP responses, robots.txt rules and possible anti-bot blocks.
+- **ProductionSafetyCrawler** – wraps site crawlers with rate limiting and
+  circuit breakers to avoid service disruption.
+- **RealDataCrawler** – fetches live flight information and validates extracted
+  prices, times and flight numbers.
+- **RealDataQualityChecker** – ensures scraped results contain realistic data.
+- **ProductionMonitoring** – exposes health metrics and alerts on crawling
+  issues.
+
+See [docs/real_data_setup.md](docs/real_data_setup.md) for full instructions.
 
 ## Adding New Websites | افزودن وب‌سایت‌های جدید
 

--- a/docs/real_data_setup.md
+++ b/docs/real_data_setup.md
@@ -1,0 +1,38 @@
+# Production Setup Guide
+
+This document summarizes how to run the crawler against live Iranian travel websites.
+
+1. **Validate Target Websites**
+   
+   Run the `production_url_validator` module to check connectivity, response times,
+   robots.txt rules and potential anti-bot blocks for each configured site:
+   ```bash
+   python -m production_url_validator
+   ```
+   Review the output and disable any site that fails validation.
+
+2. **Configure Production Endpoints**
+   
+   The file `config.py` defines `PRODUCTION_SITES` with real URLs and headers.
+   Adjust rate limits or timeouts if needed.
+
+3. **Run Crawlers Safely**
+   
+   Use `ProductionSafetyCrawler` to wrap your site crawler instances:
+   ```python
+   from production_safety_crawler import ProductionSafetyCrawler
+   safety = ProductionSafetyCrawler()
+   results = await safety.safe_crawl_with_verification("flytoday", crawler, params)
+   ```
+   This applies rate limiting, circuit breakers and robots.txt checks.
+
+4. **Verify and Monitor**
+   
+   - `verify_website_individually` in `site_verifier.py` performs a full feature
+     test on each site.
+   - `ProductionMonitoring` exposes real-time metrics and can alert on issues.
+
+5. **Quality Assurance**
+   
+   After scraping, pass the results through `RealDataQualityChecker` to ensure
+   prices and times are realistic before storing them.


### PR DESCRIPTION
## Summary
- document how to run the crawler in production
- update README with Production Setup section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langdetect')*

------
https://chatgpt.com/codex/tasks/task_e_68468a02da38832fba55e0d73a747ef2