### PR TITLE
Add sites link to navigation

### DIFF
--- a/frontend/__tests__/layout.test.tsx
+++ b/frontend/__tests__/layout.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import RootLayout from '../app/layout';
+
+// minimal wrapper to satisfy Next.js metadata usage
+function Wrapper() {
+  return (
+    <RootLayout>
+      <div />
+    </RootLayout>
+  );
+}
+
+test('navigation includes link to sites', () => {
+  render(<Wrapper />);
+  expect(screen.getByText('\u0633\u0627\u06cc\u062a\u200c\u0647\u0627')).toBeInTheDocument();
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <header className="bg-blue-600 text-white mb-4">
           <nav className="max-w-xl mx-auto flex space-x-4 rtl:space-x-reverse p-2">
             <a href="/" className="hover:underline">خانه</a>
+            <a href="/sites" className="hover:underline">سایت‌ها</a>
             <a href="/debug" className="hover:underline">اشکال‌زدایی</a>
           </nav>
         </header>


### PR DESCRIPTION
## Summary
- add navigation link to list BI sites
- cover layout nav in tests

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684690ebfc7c832fb94dc299b4e8fd2a