### PR TITLE
Persist data locally if DB down

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ DEBUG_MODE=false
 ```
 
 2. Update the configuration in `config.py` as needed.
-3. Set `DEBUG_MODE=true` to enable verbose logging during development.
-4. Validate target websites before running crawlers:
+3. If PostgreSQL is not available the crawler will automatically create a
+   `data/flight_data.sqlite` file and use it as a local database so crawled
+   flights persist across restarts.
+4. Set `DEBUG_MODE=true` to enable verbose logging during development.
+5. Validate target websites before running crawlers:
 ```bash
 python -m production_url_validator
 ```

--- a/data_manager.py
+++ b/data_manager.py
@@ -2,6 +2,7 @@ import logging
 import json
 from typing import Dict, List, Optional
 from datetime import datetime, timedelta
+from pathlib import Path
 from sqlalchemy import create_engine, Column, Integer, String, Float, DateTime, ForeignKey, JSON, func
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship, Session
@@ -82,9 +83,13 @@ class DataManager:
         try:
             self.engine = create_engine(db_url)
             self.engine.connect()
-        except Exception:
-            # Fallback to in-memory SQLite for testing environments
-            self.engine = create_engine("sqlite:///:memory:")
+        except Exception as e:
+            logger.warning(
+                f"PostgreSQL connection failed ({e}); using local SQLite database"
+            )
+            sqlite_path = Path("data") / "flight_data.sqlite"
+            sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+            self.engine = create_engine(f"sqlite:///{sqlite_path}")
         self.Session = sessionmaker(bind=self.engine)
 
         # Initialize Redis


### PR DESCRIPTION
## Summary
- keep crawler results after restarts by saving to `data/flight_data.sqlite` if PostgreSQL isn't reachable
- document fallback database behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684699b1e810832f8dcd2e19e26b54aa