### PR TITLE
Improve real data crawling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,17 @@ For real-world deployments the project includes several production utilities:
 - **RealDataQualityChecker** – ensures scraped results contain realistic data.
 - **ProductionMonitoring** – exposes health metrics and alerts on crawling
   issues.
+- **Dummy placeholders** – `FlytodayCrawler`, `PartoCRSCrawler`,
+  `PartoTicketCrawler`, `BookCharter724Crawler` and `BookCharterCrawler`
+  currently return dummy results. Replace their implementations with real
+  scraping logic or subclasses of `RealDataCrawler`.
 
 See [docs/real_data_setup.md](docs/real_data_setup.md) for full instructions.
+
+To enable real-data crawling, first run `python -m production_url_validator`
+to verify each site is accessible. Instantiate `RealDataCrawler` for your
+target and replace any dummy implementations. Always respect website terms of
+service and local regulations before scraping production systems.
 
 ## Adding New Websites | افزودن وب‌سایت‌های جدید
 

--- a/docs/real_data_setup.md
+++ b/docs/real_data_setup.md
@@ -34,5 +34,30 @@ This document summarizes how to run the crawler against live Iranian travel webs
 
 5. **Quality Assurance**
    
-   After scraping, pass the results through `RealDataQualityChecker` to ensure
-   prices and times are realistic before storing them.
+After scraping, pass the results through `RealDataQualityChecker` to ensure
+prices and times are realistic before storing them.
+
+6. **Enable Real Data Crawling**
+
+   Several crawler classes currently return placeholder results. These are
+   `FlytodayCrawler`, `PartoCRSCrawler`, `PartoTicketCrawler`,
+   `BookCharter724Crawler` and `BookCharterCrawler`. Replace their
+   `search_flights` implementations with real scraping logic or subclass
+   `RealDataCrawler`:
+
+   ```python
+   from real_data_crawler import RealDataCrawler
+
+   crawler = RealDataCrawler(rate_limiter, text_processor,
+                             monitor, error_handler)
+   flights = await crawler.extract_real_flight_data(params)
+   ```
+
+   Always validate each target by running `python -m production_url_validator`
+   before enabling real crawling.
+
+7. **Legal Considerations**
+
+   Crawling production sites may be restricted by local laws and the target
+   website's terms of service. Review `robots.txt` and obtain permission when
+   required. Use this project responsibly and at your own risk.


### PR DESCRIPTION
## Summary
- document which crawlers return dummy results
- describe how to enable real-data crawling
- add legal notice for scraping production websites

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6846b54a0134832fa97ffbae15a76851