### PR TITLE
Add module viewer pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from fastapi import FastAPI, HTTPException, WebSocket, Header, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 from config import config
 from main_crawler import IranianFlightCrawler
@@ -315,6 +316,31 @@ async def get_all_sites_status():
             "avg_response_time": monitor.get_avg_response_time(site_name)
         }
     return {"sites": sites_status, "timestamp": datetime.now().isoformat()}
+
+
+@app.get("/modules/{module_name}", response_class=PlainTextResponse)
+async def get_module_source(module_name: str):
+    """Return source code of key modules"""
+    module_paths = {
+        "main_crawler": "main_crawler.py",
+        "site_crawlers": "site_crawlers.py",
+        "monitoring": "monitoring/README.md",
+        "data_manager": "data_manager.py",
+        "intelligent_search": "intelligent_search.py",
+        "price_monitor": "price_monitor.py",
+        "flight_monitor": "flight_monitor.py",
+        "ml_predictor": "ml_predictor.py",
+        "multilingual_processor": "multilingual_processor.py",
+    }
+    path = module_paths.get(module_name)
+    if not path:
+        raise HTTPException(status_code=404, detail="Module not found")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except Exception as e:
+        logger.error(f"Error reading module {module_name}: {e}")
+        raise HTTPException(status_code=500, detail="Could not read module")
 
 
 @app.post("/api/v1/sites/{site_name}/test")

--- a/ui/index.html
+++ b/ui/index.html
@@ -141,6 +141,22 @@
             <button class="button" onclick="location.href='manual_crawl.html'">Open Manual Crawl</button>
         </div>
 
+        <!-- Modules Overview -->
+        <div class="card">
+            <h3>📚 Modules</h3>
+            <ul>
+                <li><a href="modules/main_crawler.html">main_crawler.py</a></li>
+                <li><a href="modules/site_crawlers.html">site_crawlers.py</a></li>
+                <li><a href="modules/monitoring.html">monitoring</a></li>
+                <li><a href="modules/data_manager.html">data_manager.py</a></li>
+                <li><a href="modules/intelligent_search.html">intelligent_search.py</a></li>
+                <li><a href="modules/price_monitor.html">price_monitor.py</a></li>
+                <li><a href="modules/flight_monitor.html">flight_monitor.py</a></li>
+                <li><a href="modules/ml_predictor.html">ml_predictor.py</a></li>
+                <li><a href="modules/multilingual_processor.html">multilingual_processor.py</a></li>
+            </ul>
+        </div>
+
         <!-- Site Status Monitor -->
         <div class="card">
             <h3>🌐 Site Status Monitor</h3>

--- a/ui/module.js
+++ b/ui/module.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const moduleName = document.body.dataset.module;
+  if (!moduleName) return;
+  fetch(`/modules/${moduleName}`).then(r => r.text()).then(t => {
+    document.getElementById('code').textContent = t;
+  }).catch(err => {
+    document.getElementById('code').textContent = 'Failed to load module';
+  });
+});

--- a/ui/modules/data_manager.html
+++ b/ui/modules/data_manager.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Data Manager</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="data_manager">
+  <header>Data Manager</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/flight_monitor.html
+++ b/ui/modules/flight_monitor.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Flight Monitor</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="flight_monitor">
+  <header>Flight Monitor</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/intelligent_search.html
+++ b/ui/modules/intelligent_search.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Intelligent Search</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="intelligent_search">
+  <header>Intelligent Search</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/main_crawler.html
+++ b/ui/modules/main_crawler.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Main Crawler</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="main_crawler">
+  <header>Main Crawler</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/ml_predictor.html
+++ b/ui/modules/ml_predictor.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Ml Predictor</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="ml_predictor">
+  <header>Ml Predictor</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/monitoring.html
+++ b/ui/modules/monitoring.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Monitoring</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="monitoring">
+  <header>Monitoring</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/multilingual_processor.html
+++ b/ui/modules/multilingual_processor.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Multilingual Processor</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="multilingual_processor">
+  <header>Multilingual Processor</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/price_monitor.html
+++ b/ui/modules/price_monitor.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Price Monitor</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="price_monitor">
+  <header>Price Monitor</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>

--- a/ui/modules/site_crawlers.html
+++ b/ui/modules/site_crawlers.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Site Crawlers</title>
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    pre { background: #f4f4f4; padding: 1em; overflow-x: auto; }
+  </style>
+</head>
+<body data-module="site_crawlers">
+  <header>Site Crawlers</header>
+  <pre id="code">Loading...</pre>
+  <script src="../module.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show a list of core modules on the dashboard
- add viewer HTML pages and JS to fetch source code
- expose `/modules/{module_name}` endpoint to return module text

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bc357ca8832fa2a6f998926d10c6