### PR TITLE
Fix BaseSiteCrawler execute_js

### DIFF
--- a/site_crawlers.py
+++ b/site_crawlers.py
@@ -43,10 +43,10 @@ class BaseSiteCrawler(StealthCrawler):
         self.crawler = AsyncWebCrawler(config=self.browser_config)
         self.interval = interval
     
-    async def _execute_js(self, script: str, **kwargs) -> Any:
+    async def _execute_js(self, script: str, *args) -> Any:
         """Execute JavaScript with error handling"""
         try:
-            return await self.crawler.execute_js(script, **kwargs)
+            return await self.crawler.execute_js(script, *args)
         except Exception as e:
             self.logger.error(f"JavaScript execution error: {e}")
             raise


### PR DESCRIPTION
## Summary
- ensure `_execute_js` forwards positional args to the crawler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846c23ccab4832fa76be44bb35c8275