### PR TITLE
Fix duration extraction bug

### DIFF
--- a/persian_text.py
+++ b/persian_text.py
@@ -227,14 +227,21 @@ class PersianTextProcessor:
     def extract_duration(self, duration_text: str) -> int:
         """Extract duration in minutes from text"""
         try:
-            # Remove non-numeric characters
-            duration_text = re.sub(r'[^\d]', '', self.process(duration_text))
-            
-            # Check if it's in hours
-            if 'ساعت' in duration_text or 'hour' in duration_text.lower():
-                return int(duration_text) * 60
-            
-            return int(duration_text)
+            processed = self.process(duration_text)
+
+            # Determine if the original text specified hours before
+            is_hours = 'ساعت' in processed or 'hour' in processed.lower()
+
+            # Remove non-numeric characters to extract the numeric part
+            digits_only = re.sub(r'[^\d]', '', processed)
+            if not digits_only:
+                return 0
+
+            minutes = int(digits_only)
+            if is_hours:
+                minutes *= 60
+
+            return minutes
         except Exception as e:
             print(f"Error extracting duration from {duration_text}: {e}")
             return 0

--- a/tests/test_persian_text_processor.py
+++ b/tests/test_persian_text_processor.py
@@ -34,3 +34,13 @@ def test_parse_time():
     assert isinstance(result, datetime.datetime)
     assert result.hour == 10
     assert result.minute == 30
+
+
+def test_extract_duration_hours():
+    processor = PersianTextProcessor()
+    assert processor.extract_duration("۲ ساعت") == 120
+
+
+def test_extract_duration_minutes():
+    processor = PersianTextProcessor()
+    assert processor.extract_duration("۹۰") == 90


### PR DESCRIPTION
## Summary
- fix `extract_duration` not detecting hours correctly
- add unit tests for duration extraction

## Testing
- `pytest tests/test_persian_text_processor.py::test_extract_duration_hours -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e8ba4230832fa1f74ad6ddbd2faf