### PR TITLE
Add simple website request archiver

### DIFF
--- a/requests/README.md
+++ b/requests/README.md
@@ -1,0 +1,5 @@
+# Request Archiver
+
+This folder contains a simple Python utility to fetch website content and store it locally for future crawling.
+
+Run `python url_requester.py` to open a small GUI. Enter a URL and click **Fetch**. The program saves the HTML response into the `pages` directory with a filename derived from the full URL.

--- a/requests/url_requester.py
+++ b/requests/url_requester.py
@@ -1,0 +1,49 @@
+import os
+import tkinter as tk
+from tkinter import messagebox
+import requests
+
+SAVE_DIR = os.path.join(os.path.dirname(__file__), "pages")
+
+os.makedirs(SAVE_DIR, exist_ok=True)
+
+
+def sanitize_filename(url: str) -> str:
+    """Sanitize URL to create a safe filename."""
+    safe = url.replace('://', '_').replace('/', '_').replace('?', '_')
+    return safe
+
+
+def fetch_url():
+    url = url_entry.get().strip()
+    if not url:
+        messagebox.showerror("Error", "Please enter a URL")
+        return
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        filename = sanitize_filename(url) + ".html"
+        filepath = os.path.join(SAVE_DIR, filename)
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(response.text)
+        messagebox.showinfo("Success", f"Saved HTML to {filepath}")
+    except Exception as e:
+        messagebox.showerror("Request Failed", str(e))
+
+
+root = tk.Tk()
+root.title("Website Requester")
+
+frame = tk.Frame(root)
+frame.pack(padx=10, pady=10)
+
+label = tk.Label(frame, text="Enter URL:")
+label.pack(side=tk.LEFT)
+
+url_entry = tk.Entry(frame, width=50)
+url_entry.pack(side=tk.LEFT, padx=(5, 0))
+
+fetch_button = tk.Button(root, text="Fetch", command=fetch_url)
+fetch_button.pack(pady=(5, 10))
+
+root.mainloop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ mypy>=0.931
 # Additional dependencies
 fastapi>=0.115.0
 uvicorn[standard]>=0.24.0
+requests>=2.0.0
 pydantic>=2.5.0
 sqlalchemy>=2.0.0
 alembic==1.12.1


### PR DESCRIPTION
## Summary
- add a simple Tkinter UI for fetching and saving webpages
- document the new utility in `requests/README.md`
- include `requests` library in requirements

## Testing
- `pytest -q` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6847a50594b4832fa753ef4e483b8efa