### PR TITLE
Add Flightio crawler

### DIFF
--- a/adapters/site_adapters/iranian_airlines/flightio_adapter.py
+++ b/adapters/site_adapters/iranian_airlines/flightio_adapter.py
@@ -1,0 +1,167 @@
+from typing import Dict, List, Optional
+import logging
+from bs4 import BeautifulSoup
+from playwright.async_api import TimeoutError
+
+from adapters.base_adapters.airline_crawler import AirlineCrawler
+from utils.rate_limiter import RateLimiter
+from utils.error_handler import ErrorHandler
+from utils.monitoring import Monitoring
+
+
+class FlightioAdapter(AirlineCrawler):
+    """Crawler adapter for Flightio."""
+
+    def __init__(self, config: Dict):
+        super().__init__(config)
+        self.base_url = "https://flightio.com"
+        self.search_url = config["search_url"]
+        self.rate_limiter = RateLimiter(
+            requests_per_second=config["rate_limiting"]["requests_per_second"],
+            burst_limit=config["rate_limiting"]["burst_limit"],
+            cooldown_period=config["rate_limiting"]["cooldown_period"],
+        )
+        self.error_handler = ErrorHandler(
+            max_retries=config["error_handling"]["max_retries"],
+            retry_delay=config["error_handling"]["retry_delay"],
+            circuit_breaker_config=config["error_handling"]["circuit_breaker"],
+        )
+        self.monitoring = Monitoring(config["monitoring"])
+        self.logger = logging.getLogger(__name__)
+
+    async def crawl(self, search_params: Dict) -> List[Dict]:
+        try:
+            self._validate_search_params(search_params)
+            await self._navigate_to_search_page()
+            await self._fill_search_form(search_params)
+            results = await self._extract_flight_results()
+            validated_results = self._validate_flight_data(results)
+            self.monitoring.record_success()
+            return validated_results
+        except Exception as e:
+            self.logger.error(f"Error crawling Flightio: {e}")
+            self.monitoring.record_error()
+            raise
+
+    async def _navigate_to_search_page(self) -> None:
+        try:
+            await self.page.navigate(self.search_url)
+            await self.page.wait_for_load_state("networkidle")
+        except TimeoutError:
+            self.logger.error("Timeout while loading search page")
+            raise
+
+    async def _fill_search_form(self, search_params: Dict) -> None:
+        try:
+            await self.page.fill(
+                self.config["extraction_config"]["search_form"]["origin_field"],
+                search_params["origin"],
+            )
+            await self.page.fill(
+                self.config["extraction_config"]["search_form"]["destination_field"],
+                search_params["destination"],
+            )
+            await self.page.fill(
+                self.config["extraction_config"]["search_form"]["departure_date_field"],
+                search_params["departure_date"],
+            )
+            if "return_date" in search_params:
+                await self.page.fill(
+                    self.config["extraction_config"]["search_form"]["return_date_field"],
+                    search_params["return_date"],
+                )
+            await self.page.select_option(
+                self.config["extraction_config"]["search_form"]["cabin_class_field"],
+                search_params["cabin_class"],
+            )
+            await self.page.click("button[type='submit']")
+            await self.page.wait_for_load_state("networkidle")
+        except Exception as e:
+            self.logger.error(f"Error filling search form: {e}")
+            raise
+
+    async def _extract_flight_results(self) -> List[Dict]:
+        try:
+            await self.page.wait_for_selector(
+                self.config["extraction_config"]["results_parsing"]["container"]
+            )
+            html = await self.page.content()
+            soup = BeautifulSoup(html, "html.parser")
+            flight_elements = soup.select(
+                self.config["extraction_config"]["results_parsing"]["container"]
+            )
+            results: List[Dict] = []
+            for element in flight_elements:
+                flight = self._parse_flight_element(element)
+                if flight:
+                    results.append(flight)
+            return results
+        except Exception as e:
+            self.logger.error(f"Error extracting flight results: {e}")
+            raise
+
+    def _parse_flight_element(self, element) -> Optional[Dict]:
+        try:
+            flight = {
+                "airline": element.select_one(
+                    self.config["extraction_config"]["results_parsing"]["airline"]
+                ).text.strip(),
+                "flight_number": element.select_one(
+                    self.config["extraction_config"]["results_parsing"]["flight_number"]
+                ).text.strip(),
+                "departure_time": element.select_one(
+                    self.config["extraction_config"]["results_parsing"]["departure_time"]
+                ).text.strip(),
+                "arrival_time": element.select_one(
+                    self.config["extraction_config"]["results_parsing"]["arrival_time"]
+                ).text.strip(),
+                "duration": element.select_one(
+                    self.config["extraction_config"]["results_parsing"]["duration"]
+                ).text.strip(),
+                "price": self._extract_price(
+                    element.select_one(
+                        self.config["extraction_config"]["results_parsing"]["price"]
+                    ).text.strip()
+                ),
+                "cabin_class": element.select_one(
+                    self.config["extraction_config"]["results_parsing"]["cabin_class"]
+                ).text.strip(),
+            }
+            return flight
+        except Exception as e:
+            self.logger.error(f"Error parsing flight element: {e}")
+            return None
+
+    def _extract_price(self, price_text: str) -> float:
+        try:
+            cleaned = (
+                price_text.replace("IRR", "")
+                .replace("تومان", "")
+                .replace(",", "")
+                .strip()
+            )
+            return float(cleaned)
+        except Exception as e:
+            self.logger.error(f"Error extracting price: {e}")
+            return 0.0
+
+    def _validate_search_params(self, search_params: Dict) -> None:
+        required = ["origin", "destination", "departure_date", "cabin_class"]
+        for field in required:
+            if field not in search_params:
+                raise ValueError(f"Missing required search parameter: {field}")
+
+    def _validate_flight_data(self, results: List[Dict]) -> List[Dict]:
+        validated: List[Dict] = []
+        for result in results:
+            if all(
+                field in result
+                for field in self.config["data_validation"]["required_fields"]
+            ):
+                if (
+                    self.config["data_validation"]["price_range"]["min"]
+                    <= result["price"]
+                    <= self.config["data_validation"]["price_range"]["max"]
+                ):
+                    validated.append(result)
+        return validated

--- a/config.py
+++ b/config.py
@@ -148,6 +148,7 @@ class RedisConfig:
 @dataclass
 class CrawlerConfig:
     DOMAINS: List[str] = field(default_factory=lambda: [
+        'flightio.com',
         'flytoday.ir',
         'alibaba.ir',
         'safarmarket.com',
@@ -164,6 +165,7 @@ class CrawlerConfig:
         'alibaba.ir': 2,
         'safarmarket.com': 2,
         'mz724.ir': 2,
+        'flightio.com': 2,
         'partocrs.com': 2,
         'parto-ticket.ir': 2,
         'bookcharter724.ir': 2,

--- a/config/site_configs/flightio.json
+++ b/config/site_configs/flightio.json
@@ -1,0 +1,77 @@
+{
+    "site_id": "flightio",
+    "name": "Flightio",
+    "search_url": "https://flightio.com/flight",
+    "persian_processing": {
+        "rtl_support": true,
+        "jalali_calendar": true,
+        "persian_numerals": true
+    },
+    "extraction_config": {
+        "search_form": {
+            "origin_field": "input[name=\"origin\"]",
+            "destination_field": "input[name=\"destination\"]",
+            "date_field": "input[name=\"departure_date\"]",
+            "passengers_field": "select[name=\"passengers\"]",
+            "class_field": "select[name=\"cabin_class\"]"
+        },
+        "results_parsing": {
+            "container": ".flight-result",
+            "price": ".price",
+            "airline": ".airline-name",
+            "duration": ".duration",
+            "departure_time": ".departure-time",
+            "arrival_time": ".arrival-time",
+            "flight_number": ".flight-number",
+            "seat_class": ".seat-class",
+            "available_seats": ".available-seats",
+            "aircraft_type": ".aircraft-type"
+        }
+    },
+    "data_validation": {
+        "required_fields": [
+            "airline",
+            "flight_number",
+            "departure_time",
+            "arrival_time",
+            "price",
+            "currency",
+            "seat_class",
+            "duration_minutes"
+        ],
+        "price_range": {
+            "min": 1000000,
+            "max": 100000000
+        },
+        "duration_range": {
+            "min": 30,
+            "max": 1440
+        }
+    },
+    "rate_limiting": {
+        "requests_per_second": 2,
+        "burst_limit": 5,
+        "cooldown_period": 60
+    },
+    "error_handling": {
+        "max_retries": 3,
+        "retry_delay": 5,
+        "circuit_breaker": {
+            "failure_threshold": 5,
+            "reset_timeout": 300
+        }
+    },
+    "monitoring": {
+        "metrics": [
+            "request_duration",
+            "success_rate",
+            "error_rate",
+            "flight_count",
+            "price_range"
+        ],
+        "alerts": {
+            "error_threshold": 0.1,
+            "latency_threshold": 30
+        }
+    }
+}

--- a/flight_monitor.py
+++ b/flight_monitor.py
@@ -8,6 +8,7 @@ from site_crawlers import (
     SafarmarketCrawler,
     Mz724Crawler,
     FlytodayCrawler,
+    FlightioCrawler,
     AlibabaCrawler,
 )
 
@@ -27,6 +28,9 @@ class FlightMonitoringSystem:
             ),
             'mz724.ir': Mz724Crawler(
                 self.rate_limiter, self.text_processor, self.monitor, self.error_handler, interval=1800
+            ),
+            'flightio.com': FlightioCrawler(
+                self.rate_limiter, self.text_processor, self.monitor, self.error_handler, interval=2700
             ),
             'flytoday.ir': FlytodayCrawler(
                 self.rate_limiter, self.text_processor, self.monitor, self.error_handler, interval=2700

--- a/main_crawler.py
+++ b/main_crawler.py
@@ -13,6 +13,7 @@ from monitoring import CrawlerMonitor, ErrorHandler
 from data_manager import DataManager
 from site_crawlers import (
     FlytodayCrawler,
+    FlightioCrawler,
     AlibabaCrawler,
     SafarmarketCrawler,
     Mz724Crawler,
@@ -77,6 +78,10 @@ class IranianFlightCrawler:
         
         # Initialize site crawlers
         self.crawlers = {
+            "flightio.com": FlightioCrawler(
+                self.rate_limiter, self.text_processor,
+                self.monitor, self.error_handler
+            ),
             "flytoday.ir": FlytodayCrawler(
                 self.rate_limiter, self.text_processor,
                 self.monitor, self.error_handler

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -5,6 +5,7 @@ if importlib.util.find_spec("crawl4ai") is None:
 import inspect
 from site_crawlers import (
     FlytodayCrawler,
+    FlightioCrawler,
     AlibabaCrawler,
     SafarmarketCrawler,
     Mz724Crawler,
@@ -19,6 +20,7 @@ from site_crawlers import (
 def test_crawler_classes_exist():
     for cls in [
         FlytodayCrawler,
+        FlightioCrawler,
         AlibabaCrawler,
         SafarmarketCrawler,
         Mz724Crawler,

--- a/tests/test_new_crawlers.py
+++ b/tests/test_new_crawlers.py
@@ -5,6 +5,7 @@ with open('site_crawlers.py', 'r', encoding='utf-8') as f:
     SITE_CRAWLERS_TEXT = f.read()
 
 EXPECTED_DOMAINS = {
+    'flightio.com',
     'flytoday.ir',
     'alibaba.ir',
     'safarmarket.com',
@@ -21,6 +22,7 @@ def test_domains_list():
 
 def test_crawler_classes_exist():
     for cls in [
+        'FlightioCrawler',
         'Mz724Crawler',
         'PartoCRSCrawler',
         'PartoTicketCrawler',


### PR DESCRIPTION
## Summary
- add `FlightioCrawler` implementation and adapter
- include Flightio configuration
- hook Flightio crawler into monitoring and main crawler
- update tests and domain lists

## Testing
- `pytest -k crawler_classes_exist -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d448a39c832fad13607ffad3e8d7