### PR TITLE
Add provider insights dashboard

### DIFF
--- a/frontend/__tests__/insights.test.tsx
+++ b/frontend/__tests__/insights.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ProviderInsightsPage from '../app/insights/page';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({ insights: { flights: {}, tours: {}, hotels: {} } }) })
+) as jest.Mock;
+
+test('renders provider insights tabs', async () => {
+  render(<ProviderInsightsPage />);
+  await waitFor(() => expect(screen.getByText('Flights')).toBeInTheDocument());
+  expect(screen.getByText('Tours')).toBeInTheDocument();
+  expect(screen.getByText('Hotels')).toBeInTheDocument();
+});

--- a/frontend/__tests__/layout.test.tsx
+++ b/frontend/__tests__/layout.test.tsx
@@ -13,4 +13,5 @@ function Wrapper() {
 test('navigation includes link to sites', () => {
   render(<Wrapper />);
   expect(screen.getByText('\u0633\u0627\u06cc\u062a\u200c\u0647\u0627')).toBeInTheDocument();
+  expect(screen.getByText('\u0628\u06cc\u0646\u0634\u200c\u0647\u0627')).toBeInTheDocument();
 });

--- a/frontend/app/insights/page.tsx
+++ b/frontend/app/insights/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+
+type ProviderRecords = Record<string, Record<string, number>>;
+
+interface InsightsData {
+  flights: ProviderRecords;
+  tours: ProviderRecords;
+  hotels: ProviderRecords;
+}
+
+export default function ProviderInsightsPage() {
+  const [data, setData] = useState<InsightsData | null>(null);
+  const [activeTab, setActiveTab] = useState<'flights' | 'tours' | 'hotels'>('flights');
+
+  useEffect(() => {
+    fetch('/api/v1/provider-insights')
+      .then((r) => r.json())
+      .then((d) => setData(d.insights));
+  }, []);
+
+  if (!data) return <main className="max-w-2xl mx-auto p-4">در حال بارگذاری...</main>;
+
+  const renderTable = (records: ProviderRecords) => {
+    const first = Object.values(records)[0];
+    if (!first) return <div>هیچ داده‌ای وجود ندارد</div>;
+    const headers = Object.keys(first);
+    return (
+      <table className="w-full border text-sm" data-testid="insights-table">
+        <thead>
+          <tr>
+            <th className="border p-1">Provider</th>
+            {headers.map((h) => (
+              <th key={h} className="border p-1">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(records).map(([name, metrics]) => (
+            <tr key={name} className="text-center">
+              <td className="border p-1">{name}</td>
+              {headers.map((h) => (
+                <td key={h} className="border p-1">
+                  {metrics[h] as number}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  };
+
+  return (
+    <main className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center">Provider Insights</h1>
+      <div className="flex space-x-2 rtl:space-x-reverse">
+        <button
+          className={`flex-1 p-2 border ${activeTab === 'flights' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+          onClick={() => setActiveTab('flights')}
+        >
+          Flights
+        </button>
+        <button
+          className={`flex-1 p-2 border ${activeTab === 'tours' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+          onClick={() => setActiveTab('tours')}
+        >
+          Tours
+        </button>
+        <button
+          className={`flex-1 p-2 border ${activeTab === 'hotels' ? 'bg-blue-600 text-white' : 'bg-white'}`}
+          onClick={() => setActiveTab('hotels')}
+        >
+          Hotels
+        </button>
+      </div>
+      {renderTable(data[activeTab])}
+    </main>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <nav className="max-w-xl mx-auto flex space-x-4 rtl:space-x-reverse p-2">
             <a href="/" className="hover:underline">خانه</a>
             <a href="/sites" className="hover:underline">سایت‌ها</a>
+            <a href="/insights" className="hover:underline">بینش‌ها</a>
             <a href="/debug" className="hover:underline">اشکال‌زدایی</a>
           </nav>
         </header>

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from intelligent_search import SearchOptimization
 from price_monitor import PriceMonitor, WebSocketManager, PriceAlert
 from ml_predictor import FlightPricePredictor
 from multilingual_processor import MultilingualProcessor
+from provider_insights import get_provider_insights
 
 # Configure logging
 debug_mode = os.getenv("DEBUG_MODE", "0").lower() in ("1", "true", "yes")
@@ -434,6 +435,15 @@ async def disable_site_api(site_name: str):
     if crawler.disable_site(site_name):
         return {"site": site_name, "enabled": False}
     raise HTTPException(status_code=404, detail=f"Site {site_name} not found")
+
+
+@app.get("/api/v1/provider-insights")
+async def provider_insights_api(provider_type: Optional[str] = None):
+    """Return business intelligence metrics for providers"""
+    data = get_provider_insights(provider_type)
+    if provider_type and not data:
+        raise HTTPException(status_code=404, detail="Provider type not found")
+    return {"insights": data, "timestamp": datetime.now().isoformat()}
 
 
 @app.websocket("/ws/sites/{site_name}/logs")

--- a/provider_insights.py
+++ b/provider_insights.py
@@ -1,0 +1,51 @@
+provider_insights = {
+    "flights": {
+        "AirlineA": {
+            "market_share": 25.0,
+            "on_time_performance": 92.1,
+            "avg_price_deviation": -5.0,
+            "customer_satisfaction": 4.2,
+            "route_dominance": 0.7,
+            "baggage_fee_transparency": 0.9,
+            "cancellation_rate_trend": 1.2
+        },
+        "AirlineB": {
+            "market_share": 15.0,
+            "on_time_performance": 85.3,
+            "avg_price_deviation": 3.0,
+            "customer_satisfaction": 3.8,
+            "route_dominance": 0.4,
+            "baggage_fee_transparency": 0.7,
+            "cancellation_rate_trend": 2.5
+        }
+    },
+    "tours": {
+        "TourCo": {
+            "booking_conversion": 0.12,
+            "avg_group_size": 15,
+            "seasonal_demand": 0.8,
+            "customer_repeat_rate": 0.3,
+            "price_competitiveness": 0.9,
+            "sustainability_rating": 0.6,
+            "local_partnerships": 10,
+            "avg_rating_by_category": 4.5
+        }
+    },
+    "hotels": {
+        "HotelChainX": {
+            "occupancy_rate": 0.75,
+            "revpar": 120.0,
+            "review_sentiment": 0.85,
+            "price_elasticity": 1.1,
+            "booking_window_trend": 20,
+            "competitor_pricing_position": -0.05,
+            "amenity_value_score": 0.8,
+            "repeat_guest_percentage": 0.4
+        }
+    }
+}
+
+def get_provider_insights(provider_type=None):
+    if provider_type:
+        return provider_insights.get(provider_type, {})
+    return provider_insights


### PR DESCRIPTION
## Summary
- create provider insights data and API endpoint
- add provider insights page with tabs for flights, tours, and hotels
- link new page in navigation
- test new layout link and insights page rendering

## Testing
- `pip install -q pandas jdatetime langdetect scikit-learn`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e64af734832f918b3cf1f7b5c816