### PR TITLE
Add provider insights validation tests

### DIFF
--- a/provider_insights.py
+++ b/provider_insights.py
@@ -7,7 +7,7 @@ provider_insights = {
             "customer_satisfaction": 4.2,
             "route_dominance": 0.7,
             "baggage_fee_transparency": 0.9,
-            "cancellation_rate_trend": 1.2
+            "cancellation_rate_trend": 1.2,
         },
         "AirlineB": {
             "market_share": 15.0,
@@ -16,8 +16,8 @@ provider_insights = {
             "customer_satisfaction": 3.8,
             "route_dominance": 0.4,
             "baggage_fee_transparency": 0.7,
-            "cancellation_rate_trend": 2.5
-        }
+            "cancellation_rate_trend": 2.5,
+        },
     },
     "tours": {
         "TourCo": {
@@ -28,7 +28,7 @@ provider_insights = {
             "price_competitiveness": 0.9,
             "sustainability_rating": 0.6,
             "local_partnerships": 10,
-            "avg_rating_by_category": 4.5
+            "avg_rating_by_category": 4.5,
         }
     },
     "hotels": {
@@ -40,12 +40,74 @@ provider_insights = {
             "booking_window_trend": 20,
             "competitor_pricing_position": -0.05,
             "amenity_value_score": 0.8,
-            "repeat_guest_percentage": 0.4
+            "repeat_guest_percentage": 0.4,
         }
-    }
+    },
 }
+
 
 def get_provider_insights(provider_type=None):
     if provider_type:
         return provider_insights.get(provider_type, {})
     return provider_insights
+
+
+def validate_provider_insights(provider_data):
+    """Validate that provider insight dictionaries have required keys and ranges."""
+
+    required_flight_metrics = {
+        "market_share",
+        "on_time_performance",
+        "avg_price_deviation",
+        "customer_satisfaction",
+        "route_dominance",
+        "baggage_fee_transparency",
+        "cancellation_rate_trend",
+    }
+
+    required_hotel_metrics = {
+        "occupancy_rate",
+        "revpar",
+        "review_sentiment",
+        "price_elasticity",
+        "booking_window_trend",
+        "competitor_pricing_position",
+        "amenity_value_score",
+        "repeat_guest_percentage",
+    }
+
+    required_tour_metrics = {
+        "booking_conversion",
+        "avg_group_size",
+        "seasonal_demand",
+        "customer_repeat_rate",
+        "price_competitiveness",
+        "sustainability_rating",
+        "local_partnerships",
+        "avg_rating_by_category",
+    }
+
+    validation_errors = []
+
+    for p_type, providers in provider_data.items():
+        if p_type == "flights":
+            required = required_flight_metrics
+        elif p_type == "hotels":
+            required = required_hotel_metrics
+        elif p_type == "tours":
+            required = required_tour_metrics
+        else:
+            continue
+
+        for name, metrics in providers.items():
+            missing = required - set(metrics.keys())
+            if missing:
+                validation_errors.append(f"{p_type}:{name} missing {sorted(missing)}")
+
+    flights = provider_data.get("flights", {})
+    for name, metrics in flights.items():
+        market_share = metrics.get("market_share")
+        if market_share is not None and not 0 <= market_share <= 100:
+            validation_errors.append(f"flights:{name} invalid market_share")
+
+    return validation_errors

--- a/tests/test_provider_insights.py
+++ b/tests/test_provider_insights.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from provider_insights import get_provider_insights, validate_provider_insights
+
+app = FastAPI()
+
+
+@app.get("/api/v1/provider-insights")
+async def provider_insights_route(provider_type: str | None = None):
+    data = get_provider_insights(provider_type)
+    if provider_type and not data:
+        raise HTTPException(status_code=404, detail="Provider type not found")
+    return {"insights": data}
+
+
+client = TestClient(app)
+
+
+def test_provider_insights_api():
+    resp = client.get("/api/v1/provider-insights?provider_type=flights")
+    assert resp.status_code == 200
+    data = resp.json()["insights"]
+    assert "AirlineA" in data
+
+
+def test_validate_provider_insights():
+    data = get_provider_insights()
+    errors = validate_provider_insights(data)
+    assert errors == []


### PR DESCRIPTION
## Summary
- add `validate_provider_insights` helper in `provider_insights`
- create `tests/test_provider_insights.py` to validate BI data and API route
- format files with black

## Testing
- `pytest tests/test_provider_insights.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e7e81c54832fba73ff4f1f7380f3