### PR TITLE
Add monitoring cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ For real-world deployments the project includes several production utilities:
 
 See [docs/real_data_setup.md](docs/real_data_setup.md) for full instructions.
 
+### Monitoring Stack
+
+Deployment manifests for Prometheus, Grafana and Alertmanager are stored in the
+`k8s` directory. Use the helper scripts to manage them on your cluster:
+
+```bash
+scripts/deploy-monitoring.sh   # deploys all monitoring components
+scripts/cleanup-monitoring.sh  # removes the monitoring stack
+```
+
 To enable real-data crawling, first run `python -m production_url_validator`
 to verify each site is accessible. Instantiate `RealDataCrawler` for your
 target and replace any dummy implementations. Always respect website terms of

--- a/scripts/cleanup-monitoring.sh
+++ b/scripts/cleanup-monitoring.sh
@@ -1,1 +1,16 @@
- 
+#!/bin/bash
+# Remove the monitoring stack from Kubernetes
+set -e
+
+echo "Deleting monitoring stack..."
+
+kubectl delete -f k8s/monitoring.yaml -n monitoring --ignore-not-found
+kubectl delete -f k8s/grafana-datasources.yaml -n monitoring --ignore-not-found
+kubectl delete -f k8s/grafana-dashboards.yaml -n monitoring --ignore-not-found
+kubectl delete -f k8s/grafana-provisioning.yaml -n monitoring --ignore-not-found
+kubectl delete -f k8s/grafana-secrets.yaml -n monitoring --ignore-not-found
+
+# Remove namespace last
+kubectl delete namespace monitoring --ignore-not-found
+
+echo "Monitoring stack removed."


### PR DESCRIPTION
## Summary
- implement cleanup-monitoring.sh to remove Kubernetes monitoring stack
- add execution permission for the script
- document deploy and cleanup steps in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848055d7be8832fba596fc0b035c18c