### PR TITLE
Add REDIS_URL computed from Redis settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ DB_USER=crawler
 DB_PASSWORD=secure_password
 REDIS_HOST=localhost
 REDIS_PORT=6379
+REDIS_DB=0
+REDIS_PASSWORD=
+REDIS_URL=redis://localhost:6379/0
 DEBUG_MODE=false
 ```
 


### PR DESCRIPTION
## Summary
- compute Redis URL during RedisConfig initialization
- expose REDIS_URL via `config.REDIS_URL`
- document REDIS_URL in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480557a9b8832fa4b3366130db2a13