### PR TITLE
Add request replay and filename utils

### DIFF
--- a/docs/real_data_setup.md
+++ b/docs/real_data_setup.md
@@ -56,7 +56,24 @@ prices and times are realistic before storing them.
    Always validate each target by running `python -m production_url_validator`
    before enabling real crawling.
 
-7. **Legal Considerations**
+7. **Replay Saved Requests**
+
+   Archived HTML pages can be revalidated using `scripts/replay_requests.py`:
+
+   ```bash
+   python scripts/replay_requests.py
+   ```
+
+   Schedule this command to run daily to refresh snapshots and detect DOM
+   changes.
+
+8. **Snapshot Filenames**
+
+   All snapshots use `utils.file_utils.sanitize_filename` which preserves query
+   parameters in a normalized form. This avoids prefixes like
+   `https_parto-ticket` and prevents filename collisions.
+
+9. **Legal Considerations**
 
    Crawling production sites may be restricted by local laws and the target
    website's terms of service. Review `robots.txt` and obtain permission when

--- a/requests/url_requester.py
+++ b/requests/url_requester.py
@@ -19,6 +19,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from selenium.common.exceptions import TimeoutException, WebDriverException
 import undetected_chromedriver as uc
+from utils.file_utils import sanitize_filename
 
 
 class AdvancedCrawler:
@@ -90,12 +91,6 @@ class AdvancedCrawler:
         """Add random delay to mimic human behavior."""
         time.sleep(random.uniform(0.5, 2.0))
     
-    @staticmethod
-    def sanitize_filename(url: str) -> str:
-        """Create safe filename from URL."""
-        filename = re.sub(r'^https?://', '', url)
-        filename = re.sub(r'[^\w\-_\.]', '_', filename)
-        return filename[:200]
     
     def extract_with_selenium(self, url: str) -> Tuple[str, Dict]:
         """Extract content using Selenium for JavaScript-heavy sites."""
@@ -585,7 +580,7 @@ class AdvancedCrawler:
                 progress_callback("Saving data...")
             
             # Save files
-            base_filename = self.sanitize_filename(url)
+            base_filename = sanitize_filename(url)
             
             # Save HTML
             html_path = os.path.join(self.save_dir, f"{base_filename}.html")

--- a/scripts/replay_requests.py
+++ b/scripts/replay_requests.py
@@ -1,0 +1,33 @@
+import os
+import re
+from bs4 import BeautifulSoup
+
+PAGES_DIR = os.path.join(os.path.dirname(__file__), os.pardir, 'requests', 'pages')
+
+
+def page_has_flight_results(html: str) -> bool:
+    """Simple heuristic to check if a saved page contains flight listings."""
+    soup = BeautifulSoup(html, 'html.parser')
+    if soup.select('.resu, .flight-result, .flight-item'):
+        return True
+    price_text = soup.find(string=re.compile(r'\d{1,3}(,\d{3})+'))
+    return bool(price_text)
+
+
+def replay_all() -> dict:
+    results = {}
+    for name in os.listdir(PAGES_DIR):
+        if not name.endswith('.html'):
+            continue
+        path = os.path.join(PAGES_DIR, name)
+        with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+            html = f.read()
+        results[name] = page_has_flight_results(html)
+    return results
+
+
+if __name__ == '__main__':
+    summary = replay_all()
+    for file, ok in summary.items():
+        status = 'OK' if ok else 'MISSING'
+        print(f'{file}: {status}')

--- a/site_crawlers.py
+++ b/site_crawlers.py
@@ -42,6 +42,19 @@ class BaseSiteCrawler(StealthCrawler):
         
         self.crawler = AsyncWebCrawler(config=self.browser_config)
         self.interval = interval
+
+    async def _api_fallback(self, params: Dict) -> List[Dict]:
+        """Fallback JSON API fetch for sites with dynamic pages."""
+        api_url = getattr(self, "api_url", f"{self.base_url}/api/search")
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(api_url, params=params, timeout=10) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        return data.get("flights", [])
+        except Exception as api_err:
+            self.logger.error(f"API fallback failed: {api_err}")
+        return []
     
     async def _execute_js(self, script: str, *args) -> Any:
         """Execute JavaScript with error handling"""
@@ -173,7 +186,8 @@ class FlytodayCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling Flytoday: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            fallback = await self._api_fallback(search_params)
+            return fallback
 
 class FlightioCrawler(BaseSiteCrawler):
     """Crawler for Flightio.com"""
@@ -257,7 +271,7 @@ class FlightioCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling Flightio: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class AlibabaCrawler(BaseSiteCrawler):
     """Crawler for Alibaba.ir"""
@@ -353,7 +367,7 @@ class AlibabaCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling Alibaba: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class SnapptripCrawler(BaseSiteCrawler):
     """Crawler for Snapptrip.com"""
@@ -419,7 +433,7 @@ class SnapptripCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class SafarmarketCrawler(BaseSiteCrawler):
     """Crawler for Safarmarket.com"""
@@ -513,7 +527,7 @@ class SafarmarketCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling Safarmarket: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class Mz724Crawler(BaseSiteCrawler):
     """Crawler for mz724.ir"""
@@ -607,7 +621,7 @@ class Mz724Crawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class PartoCRSCrawler(BaseSiteCrawler):
     """Crawler for partocrs.com"""
@@ -692,7 +706,7 @@ class PartoCRSCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class PartoTicketCrawler(BaseSiteCrawler):
     """Crawler for parto-ticket.ir"""
@@ -777,7 +791,7 @@ class PartoTicketCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class BookCharter724Crawler(BaseSiteCrawler):
     """Crawler for bookcharter724.ir"""
@@ -862,7 +876,7 @@ class BookCharter724Crawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class BookCharterCrawler(BaseSiteCrawler):
     """Crawler for bookcharter.ir"""
@@ -947,7 +961,7 @@ class BookCharterCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)
 
 class MrbilitCrawler(BaseSiteCrawler):
     """Crawler for mrbilit.com"""
@@ -1031,4 +1045,4 @@ class MrbilitCrawler(BaseSiteCrawler):
         except Exception as e:
             self.logger.error(f"Error crawling {self.domain}: {e}")
             await self.error_handler.handle_error(self.domain, e)
-            return []
+            return await self._api_fallback(search_params)

--- a/tasks.py
+++ b/tasks.py
@@ -173,4 +173,11 @@ async def process_price_alerts():
         
     except Exception as e:
         logger.error(f"Error processing price alerts: {e}")
-        return {'error': str(e)} 
+        return {'error': str(e)}
+
+
+@celery_app.task
+def refresh_snapshots():
+    """Run replay_requests script to validate archived pages."""
+    from scripts.replay_requests import replay_all
+    return replay_all()

--- a/tests/test_filename_utils.py
+++ b/tests/test_filename_utils.py
@@ -1,0 +1,13 @@
+from utils.file_utils import sanitize_filename
+
+
+def test_sanitize_filename_normalizes_query():
+    url = "https://parto-ticket.ir/Ticket-Tehran-Kish.html?t=1404-03-20"
+    expected = "parto-ticket.ir_Ticket-Tehran-Kish.html_t_1404-03-20"
+    assert sanitize_filename(url) == expected
+
+
+def test_sanitize_filename_query_order_irrelevant():
+    url1 = "https://example.com/search?a=1&b=2"
+    url2 = "https://example.com/search?b=2&a=1"
+    assert sanitize_filename(url1) == sanitize_filename(url2)

--- a/tests/test_real_data_validators.py
+++ b/tests/test_real_data_validators.py
@@ -1,0 +1,40 @@
+import asyncio
+from datetime import datetime, timedelta
+from real_data_crawler import RealDataCrawler
+from quality_checker import RealDataQualityChecker
+
+
+def test_validate_extracted_data():
+    crawler = RealDataCrawler.__new__(RealDataCrawler)
+    raw = [
+        {"price": 100000, "departure_time": datetime.now(), "arrival_time": datetime.now() + timedelta(hours=1)},
+        {"price": -5},
+        {"price": 500000000},
+    ]
+    valid = asyncio.run(crawler.validate_extracted_data(raw))
+    assert len(valid) == 1
+
+
+def test_real_data_quality_checker():
+    qc = RealDataQualityChecker()
+    flights = [
+        {
+            "price": 100000,
+            "origin": "THR",
+            "destination": "MHD",
+            "flight_number": "IR123",
+            "departure_time": datetime.now(),
+            "arrival_time": datetime.now() + timedelta(hours=1),
+        },
+        {
+            "price": -10,
+            "origin": "BAD",
+            "destination": "???",
+            "flight_number": "XX",
+            "departure_time": datetime.now(),
+            "arrival_time": datetime.now() - timedelta(hours=1),
+        },
+    ]
+    valid, report = asyncio.run(qc.validate_real_data_quality(flights))
+    assert len(valid) == 1
+    assert report["invalid"] == 1

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,0 +1,15 @@
+import re
+from urllib.parse import urlparse, parse_qs
+
+
+def sanitize_filename(url: str) -> str:
+    """Return a safe, normalized filename for storing a page snapshot."""
+    parsed = urlparse(url)
+    base = f"{parsed.netloc}{parsed.path}"
+    query = parse_qs(parsed.query)
+    if query:
+        normalized = "_".join(f"{k}={v[0]}" for k, v in sorted(query.items()))
+        base = f"{base}_{normalized}"
+    # Replace unsupported characters
+    filename = re.sub(r"[^\w\-_.]", "_", base)
+    return filename[:200]


### PR DESCRIPTION
## Summary
- add request replay script and new filename sanitizer
- include snapshot revalidation steps in setup guide
- use sanitizer in URL requester
- add API fallback logic for site crawlers
- schedule snapshot refresh in tasks
- test validators and sanitizer

## Testing
- `pytest tests/test_filename_utils.py tests/test_real_data_validators.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848098e05f8832f80cdcc493beb4ace