### PR TITLE
Add provider controls and manual crawl page

### DIFF
--- a/frontend/__tests__/jobs.test.tsx
+++ b/frontend/__tests__/jobs.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import CrawlJobPage from '../app/jobs/page';
+
+test('renders crawl job inputs', () => {
+  render(<CrawlJobPage />);
+  expect(screen.getByPlaceholderText('مبدا')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('مقصد')).toBeInTheDocument();
+});

--- a/frontend/__tests__/layout.test.tsx
+++ b/frontend/__tests__/layout.test.tsx
@@ -14,4 +14,5 @@ test('navigation includes link to sites', () => {
   render(<Wrapper />);
   expect(screen.getByText('\u0633\u0627\u06cc\u062a\u200c\u0647\u0627')).toBeInTheDocument();
   expect(screen.getByText('\u0628\u06cc\u0646\u0634\u200c\u0647\u0627')).toBeInTheDocument();
+  expect(screen.getByText('\u06a9\u0631\u0648\u0644 \u062c\u062f\u06cc\u062f')).toBeInTheDocument();
 });

--- a/frontend/__tests__/sites.test.tsx
+++ b/frontend/__tests__/sites.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import SitesIndex from '../app/sites/page';
+
+beforeEach(() => {
+  (global as any).fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ sites: { demo: { enabled: false } } }) })
+  ) as jest.Mock;
+});
+
+test('renders start crawling button for provider', async () => {
+  render(<SitesIndex />);
+  await waitFor(() => screen.getByText('demo'));
+  expect(screen.getByText('شروع')).toBeInTheDocument();
+});
+
+test('toggles crawling state', async () => {
+  render(<SitesIndex />);
+  await waitFor(() => screen.getByText('demo'));
+  fireEvent.click(screen.getByText('شروع'));
+  expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe('/api/v1/sites/demo/enable');
+});

--- a/frontend/app/jobs/page.tsx
+++ b/frontend/app/jobs/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+import React, { useState } from 'react';
+
+export default function CrawlJobPage() {
+  const [origin, setOrigin] = useState('');
+  const [destination, setDestination] = useState('');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [result, setResult] = useState('');
+
+  const createJob = async () => {
+    if (!origin || !destination || !start || !end) return;
+    const dates: string[] = [];
+    for (let d = new Date(start); d <= new Date(end); d.setDate(d.getDate() + 1)) {
+      dates.push(new Date(d).toISOString().split('T')[0]);
+    }
+    const res = await fetch('/crawl', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ origin, destination, dates })
+    });
+    const data = await res.json();
+    setResult(JSON.stringify(data, null, 2));
+  };
+
+  return (
+    <main className="max-w-xl mx-auto p-4 space-y-2">
+      <h1 className="text-2xl font-bold text-center">ساخت کار خزش</h1>
+      <input className="w-full p-2 border" placeholder="مبدا" value={origin} onChange={e => setOrigin(e.target.value)} />
+      <input className="w-full p-2 border" placeholder="مقصد" value={destination} onChange={e => setDestination(e.target.value)} />
+      <input type="date" className="w-full p-2 border" value={start} onChange={e => setStart(e.target.value)} />
+      <input type="date" className="w-full p-2 border" value={end} onChange={e => setEnd(e.target.value)} />
+      <button className="w-full bg-blue-600 text-white p-2" onClick={createJob}>ایجاد کار</button>
+      {result && <pre className="bg-white p-2 whitespace-pre-wrap">{result}</pre>}
+    </main>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -17,6 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <a href="/" className="hover:underline">خانه</a>
             <a href="/sites" className="hover:underline">سایت‌ها</a>
             <a href="/insights" className="hover:underline">بینش‌ها</a>
+            <a href="/jobs" className="hover:underline">کرول جدید</a>
             <a href="/debug" className="hover:underline">اشکال‌زدایی</a>
           </nav>
         </header>

--- a/frontend/app/sites/page.tsx
+++ b/frontend/app/sites/page.tsx
@@ -2,21 +2,40 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 
+interface SiteInfo {
+  enabled: boolean;
+}
+
 export default function SitesIndex() {
-  const [sites, setSites] = useState<string[]>([]);
+  const [sites, setSites] = useState<Record<string, SiteInfo>>({});
   useEffect(() => {
     fetch('/api/v1/sites/status')
       .then((r) => r.json())
-      .then((d) => setSites(Object.keys(d.sites || {})));
+      .then((d) => setSites(d.sites || {}));
   }, []);
+
+  const toggle = async (name: string, enable: boolean) => {
+    await fetch(`/api/v1/sites/${name}/${enable ? 'enable' : 'disable'}`, {
+      method: 'POST'
+    });
+    setSites((s) => ({ ...s, [name]: { ...s[name], enabled: enable } }));
+  };
 
   return (
     <main className="max-w-xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-bold text-center">Business Intelligence</h1>
-      <ul className="list-disc pl-4">
-        {sites.map((s) => (
-          <li key={s}>
-            <Link href={`/sites/${s}`}>{s}</Link>
+      <ul className="list-disc pl-4 space-y-2">
+        {Object.entries(sites).map(([name, info]) => (
+          <li key={name} className="flex items-center space-x-2 rtl:space-x-reverse">
+            <Link href={`/sites/${name}`} className="flex-1 hover:underline">
+              {name}
+            </Link>
+            <button
+              className="px-2 py-1 text-sm text-white bg-blue-600"
+              onClick={() => toggle(name, !info.enabled)}
+            >
+              {info.enabled ? 'توقف' : 'شروع'}
+            </button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- show start/stop buttons for each provider on the sites page
- add manual crawl job page with date range
- link new page from layout
- tests for new components and pages

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684811e6ba24832faf003c1b70165346