### PR TITLE
Fix serialization of error info

### DIFF
--- a/error_handler.py
+++ b/error_handler.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from datetime import datetime, timedelta
 from config import config
 
@@ -18,8 +18,14 @@ class ErrorHandler:
         self.max_errors = 5
         self.circuit_timeout = 300  # 5 minutes
     
-    async def handle_error(self, domain: str, error: str) -> None:
-        """Handle error for domain"""
+    async def handle_error(self, domain: str, error: Any) -> None:
+        """Handle error for domain.
+
+        The provided ``error`` may be an exception instance or a simple
+        string.  To ensure the value can be serialised later (e.g. when
+        sending JSON over WebSocket), it is always converted to ``str``
+        before being stored.
+        """
         try:
             # Get current time
             now = datetime.now()
@@ -30,7 +36,7 @@ class ErrorHandler:
             
             # Add error
             self.errors[domain].append({
-                'error': error,
+                'error': str(error),
                 'timestamp': now.isoformat()
             })
             


### PR DESCRIPTION
## Summary
- allow storing Exception objects in error handler
- convert errors to strings for JSON serialization

## Testing
- `python -m py_compile error_handler.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684814f46b34832fbbcf93ce8a09ee40