### PR TITLE
Fix dashboard websocket protocol

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -51,7 +51,8 @@ function connectWebSocket(userId) {
     if (ws) {
         ws.close();
     }
-    ws = new WebSocket(`ws://${location.host}/ws/prices/${encodeURIComponent(userId)}`);
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    ws = new WebSocket(`${proto}://${location.host}/ws/prices/${encodeURIComponent(userId)}`);
     ws.onmessage = (event) => {
         const el = document.getElementById('wsResult');
         el.textContent += event.data + '\n';

--- a/ui/index.html
+++ b/ui/index.html
@@ -256,7 +256,8 @@
 
         function setupWebSockets() {
             // Dashboard updates WebSocket
-            dashboardWS = new WebSocket(`ws://${window.location.host}/ws/dashboard`);
+            const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+            dashboardWS = new WebSocket(`${proto}://${window.location.host}/ws/dashboard`);
             dashboardWS.onmessage = function(event) {
                 const data = JSON.parse(event.data);
                 updateDashboard(data);


### PR DESCRIPTION
## Summary
- adjust index.html dashboard websocket initialization to respect `https` protocol
- update UI app's WebSocket connection helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848314e782c832f8a1fdbd819eb2e2e