### PR TITLE
Improve Docker build performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,6 +52,8 @@ frontend/
 node_modules/
 package.json
 package-lock.json
+chromedriver.exe
+real_request_test_results_*.json
 
 # Documentation and configs
 docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV PYTHONUNBUFFERED=1 \
 FROM base as builder
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     git \
@@ -25,7 +26,8 @@ WORKDIR /app
 
 # Copy and install Python dependencies
 COPY requirements.txt .
-RUN python -m pip install --upgrade pip \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install --upgrade pip \
     && pip install --no-cache-dir --user -r requirements.txt \
     && playwright install chromium --with-deps
 

--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,10 @@ migration:
 
 # Docker commands
 docker-build:
-	@echo "Building Docker image..."
-	docker build -t flightio-crawler .
+	@echo "Building Docker image with BuildKit cache..."
+	DOCKER_BUILDKIT=1 docker build \
+	        --build-arg BUILDKIT_INLINE_CACHE=1 \
+	        -t flightio-crawler .
 
 docker-run:
 	@echo "Running Docker container..."


### PR DESCRIPTION
## Summary
- cache apt and pip layers in Dockerfile
- ignore large artifacts in Docker context
- enable BuildKit caching in the Makefile

## Testing
- `make test` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686a5084a108832fa7b88e7eaf49658c