### PR TITLE
Fix mypy module resolution for patterns

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,0 +1,3 @@
+"""Core adapter package with shared utilities."""
+
+__all__ = []

--- a/adapters/base_adapters/enhanced_base_crawler.py
+++ b/adapters/base_adapters/enhanced_base_crawler.py
@@ -75,7 +75,8 @@ from .enhanced_error_handler import (
     error_handler_decorator,
     get_global_error_handler
 )
-from ..patterns.builder_pattern import AdapterConfigBuilder
+# Adapter configuration helpers
+from ..patterns import AdapterConfigBuilder
 from monitoring.enhanced_monitoring_system import EnhancedMonitoringSystem
 from adapters.strategies.parsing_strategies import (
     ParsingStrategyFactory,

--- a/adapters/strategies/__init__.py
+++ b/adapters/strategies/__init__.py
@@ -1,0 +1,19 @@
+"""Adapter strategies package."""
+
+from .parsing_strategies import (
+    ParseContext,
+    FlightParsingStrategy,
+    PersianParsingStrategy,
+    InternationalParsingStrategy,
+    AggregatorParsingStrategy,
+    ParsingStrategyFactory,
+)
+
+__all__ = [
+    "ParseContext",
+    "FlightParsingStrategy",
+    "PersianParsingStrategy",
+    "InternationalParsingStrategy",
+    "AggregatorParsingStrategy",
+    "ParsingStrategyFactory",
+]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,3 @@
+"""API package."""
+
+__all__ = []

--- a/crawlers/__init__.py
+++ b/crawlers/__init__.py
@@ -1,0 +1,3 @@
+"""Crawler related modules."""
+
+__all__ = []

--- a/crawlers/factories/__init__.py
+++ b/crawlers/factories/__init__.py
@@ -1,0 +1,3 @@
+"""Crawler factory subpackage."""
+
+__all__ = []

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -1,0 +1,3 @@
+"""Request handling utilities."""
+
+__all__ = []

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+"""Utility scripts package."""
+
+__all__ = []

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -1,0 +1,3 @@
+"""Security utilities package."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- expose parsing strategies and create package markers
- adjust enhanced crawler import
- add missing `__init__.py` files so mypy resolves modules

## Testing
- `mypy --config-file=mypy.ini --pretty . 2>&1 | grep 'import-not-found' | grep -E "builder_pattern|parsing_strategies" | head`

------
https://chatgpt.com/codex/tasks/task_e_686a53e29128832fbeb1eaf7e9e9bb49