### PR TITLE
Create base Dockerfile and reuse across services

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,15 +1,6 @@
 # Secure and Optimized API Dockerfile
-FROM python:3.11-slim AS base
-
-# Security and performance environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PYTHONHASHSEED=random \
-    PYTHONIOENCODING=utf-8 \
-    LANG=C.UTF-8 \
-    LC_ALL=C.UTF-8
+ARG BASE_IMAGE=flightio-base
+FROM ${BASE_IMAGE} AS base
 
 # Security labels
 LABEL maintainer="flightio-team" \
@@ -44,7 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # ---
 
 # Runtime stage with security hardening
-FROM python:3.11-slim AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 # Install security updates and minimal runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -1,15 +1,6 @@
 # Secure and Optimized Crawler Dockerfile
-FROM python:3.11-slim AS base
-
-# Security and performance environment variables
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PYTHONHASHSEED=random \
-    PYTHONIOENCODING=utf-8 \
-    LANG=C.UTF-8 \
-    LC_ALL=C.UTF-8
+ARG BASE_IMAGE=flightio-base
+FROM ${BASE_IMAGE} AS base
 
 # Security labels
 LABEL maintainer="flightio-team" \
@@ -46,7 +37,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # ---
 
 # Runtime stage with security hardening
-FROM python:3.11-slim AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 # Install security updates and minimal runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -1,9 +1,6 @@
 # Lightweight Dockerfile for Monitoring Service
-FROM python:3.11-slim AS base
-
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1
+ARG BASE_IMAGE=flightio-base
+FROM ${BASE_IMAGE} AS base
 
 # ---
 
@@ -26,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # ---
 
 # Runtime stage
-FROM python:3.11-slim AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 # Install minimal runtime dependencies for monitoring
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,9 +1,6 @@
 # Dockerfile for Background Worker Service
-FROM python:3.11-slim AS base
-
-ENV PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=1
+ARG BASE_IMAGE=flightio-base
+FROM ${BASE_IMAGE} AS base
 
 # ---
 
@@ -27,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # ---
 
 # Runtime stage
-FROM python:3.11-slim AS runtime
+FROM ${BASE_IMAGE} AS runtime
 
 # Install minimal runtime dependencies for workers
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+# Shared environment configuration
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONHASHSEED=random \
+    PYTHONIOENCODING=utf-8 \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8


### PR DESCRIPTION
## Summary
- add `docker/base.Dockerfile` for common runtime settings
- base API, crawler, monitor and worker images on the shared base
- remove repeated environment variable declarations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a7597963c832f9dd048018da01475